### PR TITLE
Fix failing test

### DIFF
--- a/src/tests/intergration/ManageZonePage.test.js
+++ b/src/tests/intergration/ManageZonePage.test.js
@@ -88,7 +88,7 @@ describe('Integration testing', () => {
     const updateButtonProp = {
       disabled: true,
       primary: true,
-      role: 'button'
+      content: 'Link Zone'
     }
     expect(wrapper.find(updateButtonProp)).toHaveLength(1)
 


### PR DESCRIPTION
Due to changes with the `PrimaryButton` component, a selector for a button in the `ManageZonePage` test was not working as expected. I've fixed it, and hopefully made it a little less brittle.