### PR TITLE
Fix plant community elevation dropdown error

### DIFF
--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityBox.js
@@ -41,7 +41,7 @@ const PlantCommunityBox = ({
     plantCommunityActions,
     purposeOfAction,
     aspect,
-    elevation,
+    elevationId,
     url,
     approved,
     notes,
@@ -134,10 +134,10 @@ const PlantCommunityBox = ({
 
             <PermissionsField
               permission={PLANT_COMMUNITY.ELEVATION}
-              name={`${namespace}.elevation`}
+              name={`${namespace}.elevationId`}
               component={Dropdown}
               options={elevationOptions}
-              displayValue={elevation ? elevationTypes[elevation].name : ''}
+              displayValue={elevationId ? elevationTypes[elevationId].name : ''}
               label={ELEVATION}
               fast
             />
@@ -271,7 +271,7 @@ PlantCommunityBox.propTypes = {
     plantCommunityActions: PropTypes.array.isRequired,
     purposeOfAction: PropTypes.string,
     aspect: PropTypes.string,
-    elevation: PropTypes.number.isRequired,
+    elevationId: PropTypes.number.isRequired,
     url: PropTypes.string,
     approved: PropTypes.bool.isRequired,
     notes: PropTypes.string.isRequired,

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
@@ -28,7 +28,6 @@ const RangeReadinessBox = ({ plantCommunity, namespace }) => {
         displayValue={rangeReadinessDate}
         label="Readiness Date"
         dateFormat="MMMM DD"
-        fast
       />
       <PermissionsField
         name={`${namespace}.rangeReadinessNotes`}

--- a/src/components/rangeUsePlanPage/schema.js
+++ b/src/components/rangeUsePlanPage/schema.js
@@ -30,7 +30,7 @@ const RUPSchema = Yup.object().shape({
           aspect: Yup.string()
             .nullable()
             .transform(handleNull()),
-          elevation: Yup.number()
+          elevationId: Yup.number()
             .required()
             .nullable()
             .transform(handleNull(0)),


### PR DESCRIPTION
The elevation dropdown component was using the `elevation` value sent from the server, when it instead should have been using `elevationId`. `elevation` is a populated object, but the dropdown expected just the id, which caused an error to be thrown.

Relates to #126.