### PR TITLE
Fix allowable AUM validation

### DIFF
--- a/src/components/rangeUsePlanPage/schema.js
+++ b/src/components/rangeUsePlanPage/schema.js
@@ -17,7 +17,7 @@ const RUPSchema = Yup.object().shape({
     Yup.object().shape({
       allowableAum: Yup.number()
         .nullable()
-        .transform(handleNull(0)),
+        .transform((v, originalValue) => (originalValue === '' ? null : v)),
       graceDays: Yup.number()
         .nullable()
         .transform(handleNull(0)),

--- a/src/components/rangeUsePlanPage/schema.js
+++ b/src/components/rangeUsePlanPage/schema.js
@@ -17,7 +17,8 @@ const RUPSchema = Yup.object().shape({
     Yup.object().shape({
       allowableAum: Yup.number()
         .nullable()
-        .transform((v, originalValue) => (originalValue === '' ? null : v)),
+        .transform((v, originalValue) => (originalValue === '' ? null : v))
+        .typeError('Please enter a number'),
       graceDays: Yup.number()
         .nullable()
         .transform(handleNull(0)),


### PR DESCRIPTION
Allows an empty value to be provided for allowable AUM, and gives a better error message for invalid inputs.

Fixes #134, fixes #135