### PR TITLE
Populate default value for indicator plants

### DIFF
--- a/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
@@ -7,18 +7,21 @@ import { Button, Confirm, Dropdown, Icon } from 'semantic-ui-react'
 import { useReferences } from '../../../providers/ReferencesProvider'
 import { REFERENCE_KEY } from '../../../constants/variables'
 import { Input, Dropdown as FormikDropdown, Form } from 'formik-semantic-ui'
-import { FieldArray, getIn } from 'formik'
+import { FieldArray, getIn, connect } from 'formik'
 
 const IndicatorPlantsForm = ({
   indicatorPlants,
   valueLabel,
+  valueType,
   criteria,
   namespace,
-  errors
+  errors,
+  formik
 }) => {
   const references = useReferences()
 
   const species = references[REFERENCE_KEY.PLANT_SPECIES] || []
+
   const options = species.map(species => ({
     key: species.id,
     value: species.id,
@@ -67,7 +70,18 @@ const IndicatorPlantsForm = ({
                         error: !!getIn(
                           errors,
                           `${namespace}.indicatorPlants.${index}.plantSpeciesId`
-                        )
+                        ),
+                        onChange: (e, { value }) => {
+                          const plantValue = species.find(s => s.id === value)[
+                            valueType
+                          ]
+                          if (plantValue) {
+                            formik.setFieldValue(
+                              `${namespace}.indicatorPlants.${index}.value`,
+                              plantValue
+                            )
+                          }
+                        }
                       }}
                     />
 
@@ -158,9 +172,10 @@ IndicatorPlantsForm.propTypes = {
   onChange: PropTypes.func,
   onSubmit: PropTypes.func,
   valueLabel: PropTypes.string.isRequired,
+  valueType: PropTypes.string.isRequired,
   criteria: PropTypes.string.isRequired,
   namespace: PropTypes.string.isRequired,
   errors: PropTypes.object
 }
 
-export default IndicatorPlantsForm
+export default connect(IndicatorPlantsForm)

--- a/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.story.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.story.js
@@ -7,8 +7,15 @@ import IndicatorPlantsForm from './IndicatorPlantsForm'
 const indicatorPlants = [
   {
     id: 0,
-    value: 5.23,
-    plantSpecies: 2
+    value: 15,
+    plantSpeciesId: 2,
+    criteria: 'stubbleHeight'
+  },
+  {
+    id: 1,
+    value: 2.5,
+    plantSpeciesId: 2,
+    criteria: 'rangeReadiness'
   }
 ]
 
@@ -22,11 +29,22 @@ storiesOf('rangeUsePlanPage/plantCommunities/IndicatorPlantsForm', module).add(
         }
       }}
       render={({ values }) => (
-        <IndicatorPlantsForm
-          indicatorPlants={values.plantCommunity.indicatorPlants}
-          namespace="plantCommunity"
-          valueLabel="Height After Grazing (cm)"
-        />
+        <>
+          <IndicatorPlantsForm
+            indicatorPlants={values.plantCommunity.indicatorPlants}
+            namespace="plantCommunity"
+            valueLabel="Criteria (Leaf Stage)"
+            valueType="leafStage"
+            criteria="rangeReadiness"
+          />
+          <IndicatorPlantsForm
+            indicatorPlants={values.plantCommunity.indicatorPlants}
+            namespace="plantCommunity"
+            valueLabel="Height After Grazing (cm)"
+            valueType="stubbleHeight"
+            criteria="stubbleHeight"
+          />
+        </>
       )}
     />
   )

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
@@ -41,6 +41,7 @@ const RangeReadinessBox = ({ plantCommunity, namespace }) => {
         indicatorPlants={plantCommunity.indicatorPlants}
         namespace={namespace}
         valueLabel="Criteria (Leaf Stage)"
+        valueType="leafStage"
         criteria={PLANT_CRITERIA.RANGE_READINESS}
         fast
       />

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/StubbleHeightBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/StubbleHeightBox.js
@@ -15,6 +15,7 @@ const StubbleHeightBox = ({ plantCommunity, namespace }) => {
         indicatorPlants={plantCommunity.indicatorPlants}
         namespace={namespace}
         valueLabel="Height After Grazing (cm)"
+        valueType="stubbleHeight"
         criteria={PLANT_CRITERIA.STUBBLE_HEIGHT}
       />
     </div>


### PR DESCRIPTION
Populates the value field for range readiness and stubble height indicator plants, based on the value provided `PLANT_SPECIES` reference. If the default value isn't specified for a given plant, the value (either leaf stage or stubble height) won't be updated.

Related to #143, #144

(Should probably wait to merge this until we have zenhub configured)