### PR TITLE
Send range readiness date as separate month and day

### DIFF
--- a/src/components/common/form/DayMonthPicker.js
+++ b/src/components/common/form/DayMonthPicker.js
@@ -4,6 +4,9 @@ import moment from 'moment'
 import { DateInput } from 'semantic-ui-calendar-react'
 
 const DayMonthPicker = ({ dayName, monthName, label, formik, ...props }) => {
+  const month = getIn(formik.values, monthName)
+  const day = getIn(formik.values, dayName)
+  const error = getIn(formik.errors, monthName)
   return (
     <>
       <DateInput
@@ -15,13 +18,25 @@ const DayMonthPicker = ({ dayName, monthName, label, formik, ...props }) => {
           formik.setFieldValue(monthName, month)
           formik.setFieldValue(dayName, day)
         }}
-        value={`${moment(getIn(formik.values, monthName), 'MM').format(
-          'MMMM'
-        )} ${moment(getIn(formik.values, dayName), 'DD').format('Do')} `}
+        value={
+          day && month
+            ? `${moment(month, 'MM').format('MMMM')} ${moment(day, 'DD').format(
+                'Do'
+              )} `
+            : ''
+        }
         dateFormat={'MMMM Do'}
         label={label}
+        error={!!error}
         {...props}
       />
+      {error && (
+        <span
+          className="sui-error-message"
+          style={{ position: 'relative', top: '-1em' }}>
+          {error}
+        </span>
+      )}
     </>
   )
 }

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
@@ -5,7 +5,7 @@ import IndicatorPlantsForm from '../IndicatorPlantsForm'
 import { PLANT_CRITERIA } from '../../../../constants/variables'
 import { RANGE_READINESS } from '../../../../constants/fields'
 import PermissionsField from '../../../common/PermissionsField'
-import DateInputField from '../../../common/form/DateInputField'
+import DayMonthPicker from '../../../common/form/DayMonthPicker'
 import { TextArea } from 'formik-semantic-ui'
 
 const RangeReadinessBox = ({ plantCommunity, namespace }) => {
@@ -22,9 +22,10 @@ const RangeReadinessBox = ({ plantCommunity, namespace }) => {
         be met before grazing may occur.
       </div>
       <PermissionsField
-        name={`${namespace}.rangeReadinessDate`}
+        monthName={`${namespace}.rangeReadinessMonth`}
+        dayName={`${namespace}.rangeReadinessDay`}
         permission={RANGE_READINESS.DATE}
-        component={DateInputField}
+        component={DayMonthPicker}
         displayValue={rangeReadinessDate}
         label="Readiness Date"
         dateFormat="MMMM DD"

--- a/src/components/rangeUsePlanPage/schema.js
+++ b/src/components/rangeUsePlanPage/schema.js
@@ -47,7 +47,14 @@ const RUPSchema = Yup.object().shape({
           url: Yup.string().transform(handleNull()),
           purposeOfAction: Yup.string().required('Required field'),
           shrubUse: Yup.string().transform(handleNull()),
-          rangeReadinessDate: Yup.string().required('Required field')
+          rangeReadinessMonth: Yup.number()
+            .transform((v, originalValue) => (originalValue === '' ? null : v))
+            .nullable()
+            .required('Required field'),
+          rangeReadinessDay: Yup.number()
+            .transform((v, originalValue) => (originalValue === '' ? null : v))
+            .nullable()
+            .required('Required field')
         })
       )
     })


### PR DESCRIPTION
Uses the `DayMonthPicker` component to set `rangeReadinessMonth` and `rangeReadinessDay` in the form instead of `rangeReadinessDate`, which doesn't set anything in the db.

Relates to #137, #167