### PR TITLE
Mark fields as required in plant communities

### DIFF
--- a/src/components/rangeUsePlanPage/index.js
+++ b/src/components/rangeUsePlanPage/index.js
@@ -134,16 +134,31 @@ const Base = ({
           Promise.all(
             pasture.plantCommunities.map(async plantCommunity => {
               let { id: communityId, ...values } = plantCommunity
+              const pastureId = newPastures[pastureIndex].id
               if (uuid.isUUID(communityId)) {
                 communityId = (await axios.post(
-                  API.CREATE_RUP_PLANT_COMMUNITY(
-                    plan.id,
-                    newPastures[pastureIndex].id
-                  ),
+                  API.CREATE_RUP_PLANT_COMMUNITY(plan.id, pastureId),
                   values,
                   config
                 )).data.id
               }
+
+              await Promise.all(
+                plantCommunity.plantCommunityActions.map(action => {
+                  let { id: actionId, ...values } = action
+                  if (uuid.isUUID(actionId)) {
+                    return axios.post(
+                      API.CREATE_RUP_PLANT_COMMUNITY_ACTION(
+                    plan.id,
+                        pastureId,
+                        communityId
+                  ),
+                  values,
+                  config
+                    )
+              }
+                })
+              )
 
               await Promise.all(
                 plantCommunity.indicatorPlants.map(plant => {
@@ -152,7 +167,7 @@ const Base = ({
                     return axios.post(
                       API.CREATE_RUP_INDICATOR_PLANT(
                         plan.id,
-                        newPastures[pastureIndex].id,
+                        pastureId,
                         communityId
                       ),
                       values,
@@ -169,7 +184,7 @@ const Base = ({
                   return axios.post(
                     API.CREATE_RUP_MONITERING_AREA(
                       plan.id,
-                      newPastures[pastureIndex].id,
+                        pastureId,
                       communityId
                     ),
                     values,

--- a/src/components/rangeUsePlanPage/index.js
+++ b/src/components/rangeUsePlanPage/index.js
@@ -145,6 +145,24 @@ const Base = ({
                 )).data.id
               }
 
+              await Promise.all(
+                plantCommunity.indicatorPlants.map(plant => {
+                  let { id: plantId, ...values } = plant
+                  if (uuid.isUUID(plantId)) {
+                    return axios.post(
+                      API.CREATE_RUP_INDICATOR_PLANT(
+                        plan.id,
+                        newPastures[pastureIndex].id,
+                        communityId
+                      ),
+                      values,
+                      config
+                    )
+                  }
+                })
+              )
+
+              await Promise.all(
               plantCommunity.monitoringAreas.map(area => {
                 let { id: areaId, ...values } = area
                 if (uuid.isUUID(areaId)) {
@@ -159,7 +177,7 @@ const Base = ({
                   )
                 }
               })
-              return Promise.resolve()
+              )
             })
           )
         )

--- a/src/components/rangeUsePlanPage/index.js
+++ b/src/components/rangeUsePlanPage/index.js
@@ -149,14 +149,14 @@ const Base = ({
                   if (uuid.isUUID(actionId)) {
                     return axios.post(
                       API.CREATE_RUP_PLANT_COMMUNITY_ACTION(
-                    plan.id,
+                        plan.id,
                         pastureId,
                         communityId
-                  ),
-                  values,
-                  config
+                      ),
+                      values,
+                      config
                     )
-              }
+                  }
                 })
               )
 
@@ -178,20 +178,20 @@ const Base = ({
               )
 
               await Promise.all(
-              plantCommunity.monitoringAreas.map(area => {
-                let { id: areaId, ...values } = area
-                if (uuid.isUUID(areaId)) {
-                  return axios.post(
-                    API.CREATE_RUP_MONITERING_AREA(
-                      plan.id,
+                plantCommunity.monitoringAreas.map(area => {
+                  let { id: areaId, ...values } = area
+                  if (uuid.isUUID(areaId)) {
+                    return axios.post(
+                      API.CREATE_RUP_MONITERING_AREA(
+                        plan.id,
                         pastureId,
-                      communityId
-                    ),
-                    values,
-                    config
-                  )
-                }
-              })
+                        communityId
+                      ),
+                      values,
+                      config
+                    )
+                  }
+                })
               )
             })
           )

--- a/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
@@ -163,9 +163,8 @@ IndicatorPlantsForm.propTypes = {
   indicatorPlants: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-      plantSpeciesId: PropTypes.number.isRequired,
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-        .isRequired,
+      plantSpeciesId: PropTypes.number,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       criteria: PropTypes.string.isRequired
     })
   ),

--- a/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
+import uuid from 'uuid-v4'
 import { NOT_PROVIDED } from '../../../constants/strings'
 import PermissionsField, { IfEditable } from '../../common/PermissionsField'
 import { STUBBLE_HEIGHT } from '../../../constants/fields'
@@ -7,7 +8,7 @@ import { Button, Confirm, Dropdown, Icon } from 'semantic-ui-react'
 import { useReferences } from '../../../providers/ReferencesProvider'
 import { REFERENCE_KEY } from '../../../constants/variables'
 import { Input, Dropdown as FormikDropdown, Form } from 'formik-semantic-ui'
-import { FieldArray, getIn, connect } from 'formik'
+import { FieldArray, connect } from 'formik'
 
 const IndicatorPlantsForm = ({
   indicatorPlants,
@@ -15,7 +16,6 @@ const IndicatorPlantsForm = ({
   valueType,
   criteria,
   namespace,
-  errors,
   formik
 }) => {
   const references = useReferences()
@@ -67,10 +67,6 @@ const IndicatorPlantsForm = ({
                           : ''
                       }
                       inputProps={{
-                        error: !!getIn(
-                          errors,
-                          `${namespace}.indicatorPlants.${index}.plantSpeciesId`
-                        ),
                         onChange: (e, { value }) => {
                           const plantValue = species.find(s => s.id === value)[
                             valueType
@@ -129,10 +125,10 @@ const IndicatorPlantsForm = ({
                 primary
                 onClick={() => {
                   push({
-                    plantSpeciesId: 0,
+                    plantSpeciesId: null,
                     value: 0,
                     criteria,
-                    id: new Date().toISOString()
+                    id: uuid()
                   })
                 }}>
                 <i className="add circle icon" />

--- a/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
@@ -34,8 +34,12 @@ const IndicatorPlantsForm = ({
   return (
     <>
       <div className="rup__plant-community__i-plant__header">
-        <div className="rup__plant-community__sh__label">Indicator Plant</div>
-        <div className="rup__plant-community__sh__label">{valueLabel}</div>
+        <div className="rup__plant-community__sh__label label--required">
+          Indicator Plant
+        </div>
+        <div className="rup__plant-community__sh__label label--required">
+          {valueLabel}
+        </div>
       </div>
 
       <FieldArray

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
@@ -147,7 +147,9 @@ const PlantCommunityActionsBox = ({ actions, namespace }) => {
             primary
             type="button"
             className="icon labeled rup__plant-communities__add-button"
-            onClick={() => push({ name: '', details: '', id: uuid() })}>
+            onClick={() =>
+              push({ actionTypeId: null, details: '', id: uuid() })
+            }>
             <i className="add circle icon" />
             Add Action
           </Button>

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
@@ -112,34 +112,37 @@ const PlantCommunityActionsBox = ({ actions, namespace }) => {
               </Form.Group>
               {actionOptions.find(
                 option => option.value === action.actionTypeId
-              ).text === 'Timing' && (
-                <Form.Group width="equal">
-                  <Form.Field width="5" />
-                  <PermissionsField
-                    monthName={`${namespace}.plantCommunityActions.${index}.noGrazeStartMonth`}
-                    dayName={`${namespace}.plantCommunityActions.${index}.noGrazeStartDay`}
-                    permission={PLANT_COMMUNITY.ACTIONS.NO_GRAZING_PERIOD}
-                    displayValue={moment(
-                      `${action.noGrazeStartMonth} ${action.noGrazeStartDay}`,
-                      'MM DD'
-                    ).format('MMMM Do')}
-                    component={DayMonthPicker}
-                    label="No Graze Start"
-                  />
+              ) &&
+                actionOptions.find(
+                  option => option.value === action.actionTypeId
+                ).text === 'Timing' && (
+                  <Form.Group width="equal">
+                    <Form.Field width="5" />
+                    <PermissionsField
+                      monthName={`${namespace}.plantCommunityActions.${index}.noGrazeStartMonth`}
+                      dayName={`${namespace}.plantCommunityActions.${index}.noGrazeStartDay`}
+                      permission={PLANT_COMMUNITY.ACTIONS.NO_GRAZING_PERIOD}
+                      displayValue={moment(
+                        `${action.noGrazeStartMonth} ${action.noGrazeStartDay}`,
+                        'MM DD'
+                      ).format('MMMM Do')}
+                      component={DayMonthPicker}
+                      label="No Graze Start"
+                    />
 
-                  <PermissionsField
-                    monthName={`${namespace}.plantCommunityActions.${index}.noGrazeEndMonth`}
-                    dayName={`${namespace}.plantCommunityActions.${index}.noGrazeEndDay`}
-                    permission={PLANT_COMMUNITY.ACTIONS.NO_GRAZING_PERIOD}
-                    displayValue={moment(
-                      `${action.noGrazeEndMonth} ${action.noGrazeEndDay}`,
-                      'MM DD'
-                    ).format('MMMM Do')}
-                    component={DayMonthPicker}
-                    label="No Graze End"
-                  />
-                </Form.Group>
-              )}
+                    <PermissionsField
+                      monthName={`${namespace}.plantCommunityActions.${index}.noGrazeEndMonth`}
+                      dayName={`${namespace}.plantCommunityActions.${index}.noGrazeEndDay`}
+                      permission={PLANT_COMMUNITY.ACTIONS.NO_GRAZING_PERIOD}
+                      displayValue={moment(
+                        `${action.noGrazeEndMonth} ${action.noGrazeEndDay}`,
+                        'MM DD'
+                      ).format('MMMM Do')}
+                      component={DayMonthPicker}
+                      label="No Graze End"
+                    />
+                  </Form.Group>
+                )}
             </div>
           ))}
           <Confirm

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { FieldArray, connect } from 'formik'
+import uuid from 'uuid-v4'
 import {
   Button,
   Form,
@@ -25,7 +26,7 @@ const PlantCommunityActionsBox = ({ actions, namespace }) => {
   const actionOptions = actionTypes
     .map(type => ({
       key: type.id,
-      value: type.name,
+      value: type.id,
       text: type.name
     }))
     .concat(otherOptions)
@@ -39,11 +40,19 @@ const PlantCommunityActionsBox = ({ actions, namespace }) => {
             <div key={action.id || `action${index}`}>
               <Form.Group widths="equal">
                 <PermissionsField
-                  name={`${namespace}.plantCommunityActions.${index}.name`}
+                  name={`${namespace}.plantCommunityActions.${index}.actionTypeId`}
                   permission={PLANT_COMMUNITY.ACTIONS.NAME}
                   component={Dropdown}
                   options={actionOptions}
-                  displayValue={action.name}
+                  displayValue={
+                    actionOptions.find(
+                      option => option.value === action.actionTypeId
+                    )
+                      ? actionOptions.find(
+                          option => option.value === action.actionTypeId
+                        ).text
+                      : ''
+                  }
                   label="Action"
                   fieldProps={{
                     width: 3,
@@ -138,7 +147,7 @@ const PlantCommunityActionsBox = ({ actions, namespace }) => {
             primary
             type="button"
             className="icon labeled rup__plant-communities__add-button"
-            onClick={() => push({ name: '', details: '' })}>
+            onClick={() => push({ name: '', details: '', id: uuid() })}>
             <i className="add circle icon" />
             Add Action
           </Button>

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
@@ -46,7 +46,8 @@ const PlantCommunityActionsBox = ({ actions, namespace }) => {
                   displayValue={action.name}
                   label="Action"
                   fieldProps={{
-                    width: 3
+                    width: 3,
+                    required: true
                   }}
                   inputProps={{
                     allowAdditions: true,
@@ -71,7 +72,8 @@ const PlantCommunityActionsBox = ({ actions, namespace }) => {
                   component={TextArea}
                   label="Details"
                   fieldProps={{
-                    width: 9
+                    width: 9,
+                    required: true
                   }}
                 />
 

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
@@ -48,7 +48,11 @@ const PlantCommunityActionsBox = ({ actions, namespace }) => {
                   displayValue={
                     actionOptions.find(
                       option => option.value === action.actionTypeId
-                    ).text || ''
+                    )
+                      ? actionOptions.find(
+                          option => option.value === action.actionTypeId
+                        ).text
+                      : ''
                   }
                   label="Action"
                   fieldProps={{

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
@@ -14,7 +14,8 @@ import { REFERENCE_KEY } from '../../../constants/variables'
 import PermissionsField, { IfEditable } from '../../common/PermissionsField'
 import { PLANT_COMMUNITY } from '../../../constants/fields'
 import { Dropdown, TextArea } from 'formik-semantic-ui'
-import DateInputField from '../../common/form/DateInputField'
+import DayMonthPicker from '../../common/form/DayMonthPicker'
+import moment from 'moment'
 
 const PlantCommunityActionsBox = ({ actions, namespace }) => {
   const [otherOptions, setOtherOptions] = useState([])
@@ -47,11 +48,7 @@ const PlantCommunityActionsBox = ({ actions, namespace }) => {
                   displayValue={
                     actionOptions.find(
                       option => option.value === action.actionTypeId
-                    )
-                      ? actionOptions.find(
-                          option => option.value === action.actionTypeId
-                        ).text
-                      : ''
+                    ).text || ''
                   }
                   label="Action"
                   fieldProps={{
@@ -109,25 +106,33 @@ const PlantCommunityActionsBox = ({ actions, namespace }) => {
                   />
                 </IfEditable>
               </Form.Group>
-              {action.name === 'Timing' && (
+              {actionOptions.find(
+                option => option.value === action.actionTypeId
+              ).text === 'Timing' && (
                 <Form.Group width="equal">
                   <Form.Field width="5" />
                   <PermissionsField
-                    name={`${namespace}.plantCommunityActions.${index}.noGrazeStart`}
+                    monthName={`${namespace}.plantCommunityActions.${index}.noGrazeStartMonth`}
+                    dayName={`${namespace}.plantCommunityActions.${index}.noGrazeStartDay`}
                     permission={PLANT_COMMUNITY.ACTIONS.NO_GRAZING_PERIOD}
-                    displayValue={action.noGrazeStart}
-                    component={DateInputField}
-                    label="No Graze Period"
-                    inline
+                    displayValue={moment(
+                      `${action.noGrazeStartMonth} ${action.noGrazeStartDay}`,
+                      'MM DD'
+                    ).format('MMMM Do')}
+                    component={DayMonthPicker}
+                    label="No Graze Start"
                   />
 
                   <PermissionsField
-                    name={`${namespace}.plantCommunityActions.${index}.noGrazeEND`}
+                    monthName={`${namespace}.plantCommunityActions.${index}.noGrazeEndMonth`}
+                    dayName={`${namespace}.plantCommunityActions.${index}.noGrazeEndDay`}
                     permission={PLANT_COMMUNITY.ACTIONS.NO_GRAZING_PERIOD}
-                    displayValue={action.noGrazeEND}
-                    component={DateInputField}
-                    label="-"
-                    inline
+                    displayValue={moment(
+                      `${action.noGrazeEndMonth} ${action.noGrazeEndDay}`,
+                      'MM DD'
+                    ).format('MMMM Do')}
+                    component={DayMonthPicker}
+                    label="No Graze End"
                   />
                 </Form.Group>
               )}

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.story.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.story.js
@@ -6,14 +6,16 @@ import PlantCommunityActionsBox from './PlantCommunityActionsBox'
 
 const plantCommunityActions = [
   {
-    name: 'Herding',
+    actionTypeId: 2,
     details: ''
   },
   {
-    name: 'Timing',
+    actionTypeId: 5,
     details: '',
-    noGrazingStart: '',
-    noGrazingEnd: ''
+    noGrazeStartMonth: 4,
+    noGrazeStartDay: 15,
+    noGrazeEndMonth: 8,
+    noGrazeEndDay: 21
   }
 ]
 

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityBox.js
@@ -162,6 +162,7 @@ const PlantCommunityBox = ({
             displayValue={notes}
             label={PLANT_COMMUNITY_NOTES}
             fast
+            fieldProps={{ required: true }}
           />
 
           <Form.Group widths="2">
@@ -182,6 +183,7 @@ const PlantCommunityBox = ({
               displayValue={purposeOfAction}
               label={PURPOSE_OF_ACTION}
               fast
+              fieldProps={{ required: true }}
             />
           </Form.Group>
 

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
@@ -7,9 +7,14 @@ import { RANGE_READINESS } from '../../../../constants/fields'
 import PermissionsField from '../../../common/PermissionsField'
 import DayMonthPicker from '../../../common/form/DayMonthPicker'
 import { TextArea } from 'formik-semantic-ui'
+import moment from 'moment'
 
 const RangeReadinessBox = ({ plantCommunity, namespace }) => {
-  const { rangeReadinessDate, rangeReadinessNotes } = plantCommunity
+  const {
+    rangeReadinessMonth,
+    rangeReadinessDay,
+    rangeReadinessNotes
+  } = plantCommunity
 
   return (
     <div className="rup__plant-community__sh">
@@ -26,7 +31,10 @@ const RangeReadinessBox = ({ plantCommunity, namespace }) => {
         dayName={`${namespace}.rangeReadinessDay`}
         permission={RANGE_READINESS.DATE}
         component={DayMonthPicker}
-        displayValue={rangeReadinessDate}
+        displayValue={moment(
+          `${rangeReadinessMonth} ${rangeReadinessDay}`,
+          'MM DD'
+        ).format('MMMM DD')}
         label="Readiness Date"
         dateFormat="MMMM DD"
         required

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
@@ -57,9 +57,8 @@ RangeReadinessBox.propTypes = {
       PropTypes.shape({
         id: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
           .isRequired,
-        plantSpeciesId: PropTypes.number.isRequired,
+        plantSpeciesId: PropTypes.number,
         value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-          .isRequired
       })
     )
   }),

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
@@ -37,7 +37,6 @@ const RangeReadinessBox = ({ plantCommunity, namespace }) => {
         ).format('MMMM DD')}
         label="Readiness Date"
         dateFormat="MMMM DD"
-        required
       />
       <PermissionsField
         name={`${namespace}.rangeReadinessNotes`}

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
@@ -29,6 +29,7 @@ const RangeReadinessBox = ({ plantCommunity, namespace }) => {
         displayValue={rangeReadinessDate}
         label="Readiness Date"
         dateFormat="MMMM DD"
+        required
       />
       <PermissionsField
         name={`${namespace}.rangeReadinessNotes`}

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/ShrubUseBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/ShrubUseBox.js
@@ -33,9 +33,8 @@ ShrubUseBox.propTypes = {
       PropTypes.shape({
         id: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
           .isRequired,
-        plantSpeciesId: PropTypes.number.isRequired,
+        plantSpeciesId: PropTypes.number,
         value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-          .isRequired
       })
     )
   }),

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/StubbleHeightBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/StubbleHeightBox.js
@@ -28,9 +28,8 @@ StubbleHeightBox.propTypes = {
       PropTypes.shape({
         id: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
           .isRequired,
-        plantSpeciesId: PropTypes.number.isRequired,
+        plantSpeciesId: PropTypes.number,
         value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-          .isRequired
       })
     )
   }),

--- a/src/components/rangeUsePlanPage/plantCommunities/monitoringArea/MonitoringAreaBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/monitoringArea/MonitoringAreaBox.js
@@ -102,6 +102,7 @@ const MonitoringAreaBox = ({
           component={Input}
           displayValue={location}
           label="Location"
+          fieldProps={{ required: true }}
         />
 
         <PermissionsField
@@ -115,6 +116,7 @@ const MonitoringAreaBox = ({
               : ''
           }
           label="Rangeland Health"
+          fieldProps={{ required: true }}
         />
       </Form.Group>
 
@@ -123,6 +125,7 @@ const MonitoringAreaBox = ({
         permission={MONITORING_AREAS.PURPOSE}
         component={Dropdown}
         options={purposeOptions}
+        fieldProps={{ required: true }}
         inputProps={{
           multiple: true
         }}

--- a/src/components/rangeUsePlanPage/schema.js
+++ b/src/components/rangeUsePlanPage/schema.js
@@ -51,12 +51,10 @@ const RUPSchema = Yup.object().shape({
           shrubUse: Yup.string().transform(handleNull()),
           rangeReadinessMonth: Yup.number()
             .transform((v, originalValue) => (originalValue === '' ? null : v))
-            .nullable()
-            .required('Required field'),
+            .nullable(),
           rangeReadinessDay: Yup.number()
             .transform((v, originalValue) => (originalValue === '' ? null : v))
-            .nullable()
-            .required('Required field'),
+            .nullable(),
           plantCommunityActions: Yup.array().of(
             Yup.object().shape({
               actionTypeId: Yup.number()

--- a/src/components/rangeUsePlanPage/schema.js
+++ b/src/components/rangeUsePlanPage/schema.js
@@ -57,6 +57,17 @@ const RUPSchema = Yup.object().shape({
             .transform((v, originalValue) => (originalValue === '' ? null : v))
             .nullable()
             .required('Required field'),
+          plantCommunityActions: Yup.array().of(
+            Yup.object().shape({
+              actionTypeId: Yup.number()
+                .transform((v, originalValue) =>
+                  originalValue === '' ? null : v
+                )
+                .nullable()
+                .required('Required field'),
+              details: Yup.string().required('Required field')
+            })
+          ),
           indicatorPlants: Yup.array().of(
             Yup.object().shape({
               plantSpeciesId: Yup.number()

--- a/src/components/rangeUsePlanPage/schema.js
+++ b/src/components/rangeUsePlanPage/schema.js
@@ -56,7 +56,24 @@ const RUPSchema = Yup.object().shape({
           rangeReadinessDay: Yup.number()
             .transform((v, originalValue) => (originalValue === '' ? null : v))
             .nullable()
-            .required('Required field')
+            .required('Required field'),
+          indicatorPlants: Yup.array().of(
+            Yup.object().shape({
+              plantSpeciesId: Yup.number()
+                .transform((v, originalValue) =>
+                  originalValue === '' ? null : v
+                )
+                .nullable()
+                .required('Required field'),
+              value: Yup.number()
+                .transform((v, originalValue) =>
+                  originalValue === '' ? null : v
+                )
+                .nullable()
+                .required('Required field')
+                .typeError('Please enter a number')
+            })
+          )
         })
       )
     })

--- a/src/components/rangeUsePlanPage/schema.js
+++ b/src/components/rangeUsePlanPage/schema.js
@@ -82,6 +82,34 @@ const RUPSchema = Yup.object().shape({
                 .required('Required field')
                 .typeError('Please enter a number')
             })
+          ),
+          monitoringAreas: Yup.array().of(
+            Yup.object().shape({
+              latitude: Yup.number()
+                .transform((v, originalValue) =>
+                  originalValue === '' ? null : v
+                )
+                .nullable()
+                .typeError('Please enter a number'),
+              longitude: Yup.number()
+                .transform((v, originalValue) =>
+                  originalValue === '' ? null : v
+                )
+                .nullable()
+                .typeError('Please enter a number'),
+              location: Yup.string()
+                .nullable()
+                .required('Required field'),
+              rangelandHealthId: Yup.number()
+                .transform((v, originalValue) =>
+                  originalValue === '' ? null : v
+                )
+                .nullable()
+                .required('Required field'),
+              purposeTypeIds: Yup.array()
+                .of(Yup.number())
+                .required('Required field')
+            })
           )
         })
       )

--- a/src/styles/Common.scss
+++ b/src/styles/Common.scss
@@ -429,3 +429,15 @@
     }
   }
 }
+
+.label {
+  &--required {
+    &::after {
+      display: inline-block;
+      vertical-align: top;
+      margin: -0.2em 0 0 0.2em;
+      content: '*';
+      color: #db2828;
+    }
+  }
+}


### PR DESCRIPTION
Marks required fields in plant communities and sub-sections as such.

Also fixes the saving of plant community actions and indicator plants, which wasn't implemented.

Relates to #165, #231 