### PR TITLE
Store PLD percentage as decimal

### DIFF
--- a/src/components/common/form/ErrorMessage.js
+++ b/src/components/common/form/ErrorMessage.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const ErrorMessage = ({ message }) => (
+  <span className="sui-error-message">{message}</span>
+)
+
+export default ErrorMessage

--- a/src/components/common/form/InputRef.js
+++ b/src/components/common/form/InputRef.js
@@ -1,0 +1,13 @@
+import React, { Fragment } from 'react'
+import { Ref } from 'semantic-ui-react'
+
+const findInput = (cb, el) => el && cb(el.querySelector('input'))
+
+export const NullRef = ({ children }) => <Fragment>{children}</Fragment>
+
+export const InputRef = ({ inputRef, children }) => {
+  const RefWrapper = inputRef ? Ref : NullRef
+  return (
+    <RefWrapper innerRef={el => findInput(inputRef, el)}>{children}</RefWrapper>
+  )
+}

--- a/src/components/common/form/PercentField.js
+++ b/src/components/common/form/PercentField.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import { Field, FastField, getIn } from 'formik'
+import { Form, Input } from 'semantic-ui-react'
+import { InputRef } from './InputRef'
+import ErrorMessage from './ErrorMessage'
+
+const PercentField = ({
+  name,
+  label,
+  validate,
+  inputProps = {},
+  fieldProps = {},
+  errorComponent = ErrorMessage,
+  inputRef,
+  fast
+}) => {
+  const id = `percent_field_${name}`
+  const { onChange, ...safeInputProps } = inputProps
+  const DesiredField = fast === true ? FastField : Field
+
+  return (
+    <DesiredField
+      name={name}
+      validate={validate}
+      render={({ field, form }) => {
+        const error = getIn(form.errors, name)
+
+        return (
+          <Form.Field error={!!error} {...fieldProps}>
+            {!!label && <label htmlFor={id}>{label}</label>}
+
+            <InputRef inputRef={inputRef}>
+              <Input
+                id={id}
+                name={name}
+                {...safeInputProps}
+                value={
+                  !isNaN(parseFloat(field.value))
+                    ? field.value * 100
+                    : field.value
+                }
+                onChange={(e, { name, value }) => {
+                  form.setFieldValue(
+                    field.name,
+                    !isNaN(parseFloat(value)) ? value / 100 : value.trim()
+                  )
+                  Promise.resolve().then(() => {
+                    onChange && onChange(e, { name, value })
+                  })
+                }}
+                onBlur={form.handleBlur}
+              />
+            </InputRef>
+
+            {error &&
+              React.createElement(errorComponent, {
+                message: error
+              })}
+          </Form.Field>
+        )
+      }}
+    />
+  )
+}
+
+export default PercentField

--- a/src/components/rangeUsePlanPage/index.js
+++ b/src/components/rangeUsePlanPage/index.js
@@ -97,7 +97,7 @@ const Base = ({
       managementConsiderations,
       ministerIssues,
       additionalRequirements
-    } = plan
+    } = RUPSchema.cast(plan)
 
     const config = getAuthHeaderConfig()
 

--- a/src/components/rangeUsePlanPage/pastures/PastureBox.js
+++ b/src/components/rangeUsePlanPage/pastures/PastureBox.js
@@ -9,6 +9,7 @@ import * as strings from '../../../constants/strings'
 import { IMAGE_SRC } from '../../../constants/variables'
 import PlantCommunities from '../plantCommunities'
 import { getIn, connect } from 'formik'
+import PercentField from '../../common/form/PercentField'
 
 const dropdownOptions = [{ key: 'copy', value: 'copy', text: 'Copy' }]
 
@@ -88,9 +89,14 @@ const PastureBox = ({
               <PermissionsField
                 name={`${namespace}.pldPercent`}
                 permission={PASTURES.PLD}
-                component={Input}
+                component={PercentField}
                 displayValue={pasture.pldPercent}
                 label={strings.PRIVATE_LAND_DEDUCTION}
+                inputProps={{
+                  label: '%',
+                  labelPosition: 'right',
+                  type: 'number'
+                }}
                 fast
               />
             </div>

--- a/src/components/rangeUsePlanPage/schema.js
+++ b/src/components/rangeUsePlanPage/schema.js
@@ -30,7 +30,7 @@ const RUPSchema = Yup.object().shape({
       planId: Yup.number(),
       pldPercent: Yup.number()
         .min(0, 'Please enter a value between 0 and 100')
-        .max(100, 'Please enter a value between 0 and 100')
+        .max(1, 'Please enter a value between 0 and 100')
         .transform((v, originalValue) => (originalValue === '' ? null : v))
         .nullable()
         .typeError('Please enter a number'),


### PR DESCRIPTION
The textfield presented to the user still expects percentage formatted numbers, not decimals. This is just to align with the behaviour of the iOS app, to ensure it remains consistent.

Relates to #221 