### PR TITLE
Create custom month and day picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7931,8 +7931,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7950,13 +7949,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7969,18 +7966,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8083,8 +8077,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8094,7 +8087,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8107,20 +8099,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8137,7 +8126,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8210,8 +8198,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8221,7 +8208,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8297,8 +8283,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8328,7 +8313,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8346,7 +8330,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8385,13 +8368,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -12381,10 +12362,6 @@
         }
       }
     },
-    "file-saver": {
-      "version": "github:eligrey/FileSaver.js#e865e37af9f9947ddcced76b549e27dc45c1cb2e",
-      "from": "file-saver@github:eligrey/FileSaver.js#e865e37af9f9947ddcced76b549e27dc45c1cb2e"
-    },
     "file-system-cache": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-1.0.5.tgz",
@@ -13757,8 +13734,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -13776,13 +13752,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -13795,18 +13769,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -13909,8 +13880,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -13920,7 +13890,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -13933,20 +13902,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -13963,7 +13929,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -14036,8 +14001,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -14047,7 +14011,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -14123,8 +14086,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -14154,7 +14116,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -14172,7 +14133,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -14211,13 +14171,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -19378,11 +19336,17 @@
       "integrity": "sha512-J9X76xnncMw+wIqb15HeWfPMqPwYxSpPY8yWPJ7rAZN/ZDzFkjCSZObryCyUe8zbrVRNiuCnIeQteCzMn7GnWw==",
       "requires": {
         "canvg": "1.5.3",
-        "file-saver": "file-saver@github:eligrey/FileSaver.js#e865e37af9f9947ddcced76b549e27dc45c1cb2e",
+        "file-saver": "github:eligrey/FileSaver.js#e865e37af9f9947ddcced76b549e27dc45c1cb2e",
         "html2canvas": "1.0.0-alpha.12",
         "omggif": "1.0.7",
         "promise-polyfill": "8.1.0",
         "stackblur-canvas": "2.2.0"
+      },
+      "dependencies": {
+        "file-saver": {
+          "version": "github:eligrey/FileSaver.js#e865e37af9f9947ddcced76b549e27dc45c1cb2e",
+          "from": "github:eligrey/FileSaver.js#1.3.8"
+        }
       }
     },
     "jspdf-autotable": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "jspdf": "^1.5.3",
     "jspdf-autotable": "^3.0.10",
     "jwt-decode": "^2.2.0",
+    "lodash": "^4.17.15",
     "lodash.debounce": "^4.0.8",
     "moment": "^2.22.2",
     "node-sass": "^4.10.0",

--- a/src/components/common/form/DayMonthPicker.js
+++ b/src/components/common/form/DayMonthPicker.js
@@ -54,7 +54,7 @@ const DayMonthPicker = connect(
             trigger={
               <>
                 <Input
-                  onFocus={() => setOpen(true)}
+                  onClick={() => setOpen(true)}
                   value={
                     dayValue && monthValue
                       ? `${moment(monthValue, 'MM').format('MMMM')} ${moment(
@@ -123,8 +123,6 @@ const DayMonthPicker = connect(
 
                             formik.setFieldValue(monthName, date.month() + 1)
                             formik.setFieldValue(dayName, date.date())
-
-                            setOpen(false)
                           }}
                           style={{
                             backgroundColor:

--- a/src/components/common/form/DayMonthPicker.js
+++ b/src/components/common/form/DayMonthPicker.js
@@ -1,44 +1,161 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { getIn, connect } from 'formik'
 import moment from 'moment'
-import { DateInput } from 'semantic-ui-calendar-react'
+import { chunk } from 'lodash'
+import {
+  Input,
+  Form,
+  Popup,
+  Button,
+  Header,
+  Grid,
+  Divider,
+  Table,
+  Icon
+} from 'semantic-ui-react'
 
-const DayMonthPicker = ({ dayName, monthName, label, formik, ...props }) => {
-  const month = getIn(formik.values, monthName)
-  const day = getIn(formik.values, dayName)
-  const error = getIn(formik.errors, monthName)
-  return (
-    <>
-      <DateInput
-        onChange={(e, { value }) => {
-          const date = moment(value, 'MMMM Do')
-          const month = date.month() + 1
-          const day = date.date()
+const DayMonthPicker = connect(
+  ({ dayName, monthName, label, formik, ...props }) => {
+    const [open, setOpen] = useState(false)
+    const [currentMonth, setCurrentMonth] = useState(0)
 
-          formik.setFieldValue(monthName, month)
-          formik.setFieldValue(dayName, day)
-        }}
-        value={
-          day && month
-            ? `${moment(month, 'MM').format('MMMM')} ${moment(day, 'DD').format(
-                'Do'
-              )} `
-            : ''
-        }
-        dateFormat={'MMMM Do'}
-        label={label}
-        error={!!error}
-        {...props}
-      />
-      {error && (
-        <span
-          className="sui-error-message"
-          style={{ position: 'relative', top: '-1em' }}>
-          {error}
-        </span>
-      )}
-    </>
-  )
-}
+    const previousMonth = () =>
+      setCurrentMonth(currentMonth > 0 ? currentMonth - 1 : 11)
+    const nextMonth = () =>
+      setCurrentMonth(currentMonth < 11 ? currentMonth + 1 : 0)
+
+    const monthValue = getIn(formik.values, monthName)
+    const dayValue = getIn(formik.values, dayName)
+    const error = getIn(formik.errors, monthName)
+
+    useEffect(() => {
+      if (monthValue) {
+        setCurrentMonth(monthValue - 1)
+      }
+    }, [open])
+
+    const daysInMonth = moment()
+      .set('month', currentMonth)
+      .daysInMonth()
+
+    const weeksArray = chunk(
+      Array.from({ length: daysInMonth }).map((_, i) => i + 1),
+      7
+    )
+
+    return (
+      <>
+        <Form.Field>
+          {label && <label>{label}</label>}
+
+          <Popup
+            open={open}
+            onClose={() => setOpen(false)}
+            trigger={
+              <>
+                <Input
+                  onFocus={() => setOpen(true)}
+                  value={
+                    dayValue && monthValue
+                      ? `${moment(monthValue, 'MM').format('MMMM')} ${moment(
+                          dayValue,
+                          'DD'
+                        ).format('Do')} `
+                      : ''
+                  }
+                  icon={
+                    monthValue || dayValue ? (
+                      <Icon
+                        name="close"
+                        link
+                        onClick={() => {
+                          formik.setFieldValue(monthName, '')
+                          formik.setFieldValue(dayName, '')
+                        }}
+                      />
+                    ) : (
+                      'calendar'
+                    )
+                  }
+                  iconPosition="right"
+                  {...props}
+                />
+                {error && (
+                  <span
+                    className="sui-error-message"
+                    style={{ position: 'relative', top: '-1em' }}>
+                    {error}
+                  </span>
+                )}
+              </>
+            }>
+            <Popup.Content style={{ width: '300px' }}>
+              <Grid>
+                <Grid.Column textAlign="left" width="4">
+                  <Button icon="caret left" onClick={previousMonth} />
+                </Grid.Column>
+                <Grid.Column verticalAlign="middle" width="8">
+                  <Header as="h4" textAlign="center">
+                    {moment()
+                      .month(currentMonth)
+                      .format('MMMM')}
+                  </Header>
+                </Grid.Column>
+                <Grid.Column textAlign="right" width="4">
+                  <Button icon="caret right" onClick={nextMonth} />
+                </Grid.Column>
+              </Grid>
+              <Divider />
+              <Table columns="7" celled>
+                {weeksArray.map((days, week) => (
+                  <Table.Row key={`${currentMonth}_week_${week}`}>
+                    <>
+                      {days.map(day => (
+                        <Table.Cell
+                          selectable
+                          textAlign="center"
+                          verticalAlign="middle"
+                          key={`${currentMonth}_day_${day}`}
+                          onClick={() => {
+                            const date = moment()
+                              .set('month', currentMonth)
+                              .set('date', day)
+
+                            formik.setFieldValue(monthName, date.month() + 1)
+                            formik.setFieldValue(dayName, date.date())
+
+                            setOpen(false)
+                          }}
+                          style={{
+                            backgroundColor:
+                              dayValue === day &&
+                              monthValue === currentMonth + 1
+                                ? '#2185d0'
+                                : 'transparent',
+                            color:
+                              dayValue === day &&
+                              monthValue === currentMonth + 1
+                                ? '#ffffff'
+                                : 'black',
+                            cursor: 'pointer'
+                          }}>
+                          {day}
+                        </Table.Cell>
+                      ))}
+                      {days.length < 7 &&
+                        Array.from({ length: 7 - days.length }).map((_, i) => (
+                          <Table.Cell key={`${currentMonth}_emptycell_${i}`} />
+                        ))}
+                    </>
+                  </Table.Row>
+                ))}
+              </Table>
+            </Popup.Content>
+          </Popup>
+        </Form.Field>
+      </>
+    )
+  }
+)
 
 export default connect(DayMonthPicker)


### PR DESCRIPTION
Customizing the DateInput from semantic-ui-calendar-react wasn't enough for our-use case, so I've created a DayMonthPicker from scratch which allows a user to pick just a month and day, without a year.

Relates to #137, #166 and #248