### PR TITLE
Set indicator plants value to 1 decimal place

### DIFF
--- a/src/components/common/form/DecimalField.js
+++ b/src/components/common/form/DecimalField.js
@@ -1,0 +1,93 @@
+import React, { useEffect } from 'react'
+import { Field, FastField, getIn } from 'formik'
+import { Form, Input } from 'semantic-ui-react'
+import { InputRef } from './InputRef'
+import ErrorMessage from './ErrorMessage'
+
+const DecimalField = ({
+  name,
+  label,
+  validate,
+  inputProps = {},
+  fieldProps = {},
+  errorComponent = ErrorMessage,
+  inputRef,
+  fast
+}) => {
+  const DesiredField = fast === true ? FastField : Field
+
+  return (
+    <DesiredField
+      name={name}
+      validate={validate}
+      render={({ field, form }) => (
+        <DecimalInput
+          name={name}
+          field={field}
+          form={form}
+          label={label}
+          fieldProps={fieldProps}
+          errorComponent={errorComponent}
+          inputRef={inputRef}
+          inputProps={inputProps}
+        />
+      )}
+    />
+  )
+}
+
+const DecimalInput = ({
+  name,
+  label,
+  inputProps,
+  fieldProps,
+  errorComponent,
+  inputRef,
+  form,
+  field
+}) => {
+  const { onChange, ...safeInputProps } = inputProps
+  const id = `decimal_field_${name}`
+
+  const error = getIn(form.errors, name)
+
+  useEffect(() => {
+    form.setFieldValue(field.name, parseFloat(field.value).toFixed(1))
+  }, [])
+
+  return (
+    <Form.Field error={!!error} {...fieldProps}>
+      {!!label && <label htmlFor={id}>{label}</label>}
+
+      <InputRef inputRef={inputRef}>
+        <Input
+          id={id}
+          name={name}
+          type="number"
+          {...safeInputProps}
+          value={field.value}
+          onBlur={(...args) => {
+            if (!isNaN(parseFloat(field.value))) {
+              form.setFieldValue(field.name, parseFloat(field.value).toFixed(1))
+            }
+
+            form.handleBlur(...args)
+          }}
+          onChange={(e, { name, value }) => {
+            form.setFieldValue(field.name, value)
+            Promise.resolve().then(() => {
+              onChange && onChange(e, { name, value })
+            })
+          }}
+        />
+      </InputRef>
+
+      {error &&
+        React.createElement(errorComponent, {
+          message: error
+        })}
+    </Form.Field>
+  )
+}
+
+export default DecimalField

--- a/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
@@ -9,6 +9,7 @@ import { useReferences } from '../../../providers/ReferencesProvider'
 import { REFERENCE_KEY } from '../../../constants/variables'
 import { Input, Dropdown as FormikDropdown, Form } from 'formik-semantic-ui'
 import { FieldArray, connect } from 'formik'
+import DecimalField from '../../common/form/DecimalField'
 
 const IndicatorPlantsForm = ({
   indicatorPlants,
@@ -112,11 +113,8 @@ const IndicatorPlantsForm = ({
                         <PermissionsField
                           permission={STUBBLE_HEIGHT.INDICATOR_PLANTS}
                           name={`${namespace}.indicatorPlants.${index}.value`}
-                          component={Input}
+                          component={DecimalField}
                           displayValue={plant.value}
-                          inputProps={{
-                            type: 'number'
-                          }}
                         />
                       </Form.Group>
                     </Grid.Column>
@@ -159,7 +157,7 @@ const IndicatorPlantsForm = ({
                 onClick={() => {
                   push({
                     plantSpeciesId: null,
-                    value: 0,
+                    value: '0.0',
                     name: null,
                     criteria,
                     id: uuid()

--- a/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
@@ -20,7 +20,8 @@ const IndicatorPlantsForm = ({
 }) => {
   const references = useReferences()
 
-  const species = references[REFERENCE_KEY.PLANT_SPECIES] || []
+  const species =
+    references[REFERENCE_KEY.PLANT_SPECIES].filter(s => !s.isShrubUse) || []
 
   const options = species.map(species => ({
     key: species.id,

--- a/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.story.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.story.js
@@ -20,7 +20,7 @@ const indicatorPlants = [
   {
     id: 2,
     value: 2.5,
-    plantSpeciesId: 81,
+    plantSpeciesId: 56,
     criteria: 'rangeReadiness'
   }
 ]


### PR DESCRIPTION
Uses a new DecimalField component to ensure that indicator plant values always display to one decimal place. Also filters out shrubs from the indicator plant type dropdown.

Relates to #178, #239, #176