### PR TITLE
Break out plan API calls into separate file

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,0 +1,329 @@
+import uuid from 'uuid-v4'
+import { axios, getAuthHeaderConfig } from '../utils'
+import * as API from '../constants/api'
+
+export const getPlan = async planId => {
+  const { data } = await axios.get(API.GET_RUP(planId), getAuthHeaderConfig())
+
+  return data
+}
+
+export const saveGrazingSchedules = (planId, grazingSchedules) => {
+  return Promise.all(
+    grazingSchedules.map(async schedule => {
+      if (uuid.isUUID(schedule.id)) {
+        const { id, ...grazingSchedule } = schedule
+        const { data } = await axios.post(
+          API.CREATE_RUP_GRAZING_SCHEDULE(planId),
+          { ...grazingSchedule, plan_id: planId },
+          getAuthHeaderConfig()
+        )
+
+        return {
+          ...grazingSchedule,
+          id: data.id
+        }
+      } else {
+        await axios.put(
+          API.UPDATE_RUP_GRAZING_SCHEDULE(planId, schedule.id),
+          { ...schedule },
+          getAuthHeaderConfig()
+        )
+
+        return schedule
+      }
+    })
+  )
+}
+
+export const saveInvasivePlantChecklist = async (
+  planId,
+  invasivePlantChecklist
+) => {
+  if (invasivePlantChecklist && invasivePlantChecklist.id) {
+    await axios.put(
+      API.UPDATE_RUP_INVASIVE_PLANT_CHECKLIST(
+        planId,
+        invasivePlantChecklist.id
+      ),
+      invasivePlantChecklist,
+      getAuthHeaderConfig()
+    )
+
+    return invasivePlantChecklist
+  } else {
+    const { id, ...values } = invasivePlantChecklist
+    const { data } = await axios.post(
+      API.CREATE_RUP_INVASIVE_PLANT_CHECKLIST(planId),
+      values,
+      getAuthHeaderConfig()
+    )
+
+    return {
+      ...invasivePlantChecklist,
+      id: data.id
+    }
+  }
+}
+
+export const saveManagementConsiderations = (
+  planId,
+  managementConsiderations
+) => {
+  return Promise.all(
+    managementConsiderations.map(async consideration => {
+      if (uuid.isUUID(consideration.id)) {
+        const { id, ...values } = consideration
+        const { data } = await axios.post(
+          API.CREATE_RUP_MANAGEMENT_CONSIDERATION(planId),
+          values,
+          getAuthHeaderConfig()
+        )
+
+        return {
+          ...consideration,
+          id: data.id
+        }
+      } else {
+        await axios.put(
+          API.UPDATE_RUP_MANAGEMENT_CONSIDERATION(planId, consideration.id),
+          consideration,
+          getAuthHeaderConfig()
+        )
+
+        return consideration
+      }
+    })
+  )
+}
+
+export const saveAdditionalRequirements = (planId, additionalRequirements) => {
+  return Promise.all(
+    additionalRequirements.map(async requirement => {
+      if (uuid.isUUID(requirement.id)) {
+        const { id, ...values } = requirement
+        const { data } = await axios.post(
+          API.CREATE_RUP_ADDITIONAL_REQUIREMENT(planId),
+          values,
+          getAuthHeaderConfig()
+        )
+
+        return {
+          ...requirement,
+          id: data.id
+        }
+      }
+    })
+  )
+}
+
+export const saveMinisterIssues = (planId, ministerIssues, newPastures) => {
+  const pastureMap = newPastures.reduce(
+    (map, p) => ({
+      ...map,
+      [p.oldId]: p.id
+    }),
+    {}
+  )
+  console.log(pastureMap)
+
+  return Promise.all(
+    ministerIssues.map(async issue => {
+      const { id, ...issueBody } = issue
+
+      if (uuid.isUUID(issue.id)) {
+        const { data: newIssue } = await axios.post(
+          API.CREATE_RUP_MINISTER_ISSUE(planId),
+          {
+            ...issueBody,
+            pastures: issueBody.pastures.map(p => pastureMap[p])
+          },
+          getAuthHeaderConfig()
+        )
+
+        const newActions = await saveMinisterIssueActions(
+          planId,
+          newIssue.id,
+          issue.ministerIssueActions
+        )
+
+        return {
+          ...issue,
+          ministerIssueActions: newActions,
+          id: newIssue.id
+        }
+      } else {
+        await axios.put(
+          API.UPDATE_RUP_MINISTER_ISSUE(planId, issue.id),
+          {
+            ...issueBody,
+            pastures: issueBody.pastures.map(p => pastureMap[p])
+          },
+          getAuthHeaderConfig()
+        )
+
+        const newActions = await saveMinisterIssueActions(
+          planId,
+          issue.id,
+          issue.ministerIssueActions
+        )
+
+        return {
+          ...issue,
+          ministerIssueActions: newActions
+        }
+      }
+    })
+  )
+}
+
+const saveMinisterIssueActions = (planId, issueId, actions) => {
+  return Promise.all(
+    actions.map(async action => {
+      const { id, ...actionBody } = action
+      if (uuid.isUUID(action.id)) {
+        const { data } = await axios.post(
+          API.CREATE_RUP_MINISTER_ISSUE_ACTION(planId, issueId),
+          actionBody,
+          getAuthHeaderConfig()
+        )
+
+        return {
+          ...action,
+          id: data.id
+        }
+      } else {
+        await axios.put(
+          API.UPDATE_RUP_MINISTER_ISSUE_ACTION(planId, issueId, action.id),
+          actionBody,
+          getAuthHeaderConfig()
+        )
+
+        return action
+      }
+    })
+  )
+}
+
+export const savePastures = (planId, pastures) => {
+  return Promise.all(
+    pastures.map(async pasture => {
+      if (Number.isInteger(pasture.id)) {
+        await axios.put(
+          API.UPDATE_RUP_PASTURE(planId, pasture.id),
+          pasture,
+          getAuthHeaderConfig()
+        )
+
+        return { ...pasture, oldId: pasture.id }
+      } else {
+        const { id, ...values } = pasture
+        const { data } = axios.post(
+          API.CREATE_RUP_PASTURE(planId),
+          values,
+          getAuthHeaderConfig()
+        )
+
+        return {
+          ...pasture,
+          oldId: pasture.id,
+          id: data.id
+        }
+      }
+    })
+  )
+}
+
+export const savePlantCommunities = (planId, pastureId, plantCommunities) => {
+  return Promise.all(
+    plantCommunities.map(async plantCommunity => {
+      let { id: communityId, ...values } = plantCommunity
+      if (uuid.isUUID(communityId)) {
+        communityId = (await axios.post(
+          API.CREATE_RUP_PLANT_COMMUNITY(planId, pastureId),
+          values,
+          getAuthHeaderConfig()
+        )).data.id
+      }
+
+      await savePlantCommunityActions(
+        planId,
+        pastureId,
+        communityId,
+        plantCommunity.plantCommunityActions
+      )
+      await saveIndicatorPlants(
+        planId,
+        pastureId,
+        communityId,
+        plantCommunity.indicatorPlants
+      )
+      await saveMonitoringAreas(
+        planId,
+        pastureId,
+        communityId,
+        plantCommunity.monitoringAreas
+      )
+    })
+  )
+}
+
+const savePlantCommunityActions = (
+  planId,
+  pastureId,
+  communityId,
+  plantCommunityActions
+) => {
+  return Promise.all(
+    plantCommunityActions.map(action => {
+      let { id: actionId, ...values } = action
+      if (uuid.isUUID(actionId)) {
+        return axios.post(
+          API.CREATE_RUP_PLANT_COMMUNITY_ACTION(planId, pastureId, communityId),
+          values,
+          getAuthHeaderConfig()
+        )
+      }
+    })
+  )
+}
+
+const saveIndicatorPlants = (
+  planId,
+  pastureId,
+  communityId,
+  indicatorPlants
+) => {
+  return Promise.all(
+    indicatorPlants.map(plant => {
+      let { id: plantId, ...values } = plant
+      if (uuid.isUUID(plantId)) {
+        return axios.post(
+          API.CREATE_RUP_INDICATOR_PLANT(planId, pastureId, communityId),
+          values,
+          getAuthHeaderConfig()
+        )
+      }
+    })
+  )
+}
+
+const saveMonitoringAreas = (
+  planId,
+  pastureId,
+  communityId,
+  monitoringAreas
+) => {
+  return Promise.all(
+    monitoringAreas.map(area => {
+      let { id: areaId, ...values } = area
+      if (uuid.isUUID(areaId)) {
+        return axios.post(
+          API.CREATE_RUP_MONITERING_AREA(planId, pastureId, communityId),
+          values,
+          getAuthHeaderConfig()
+        )
+      }
+    })
+  )
+}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -125,7 +125,6 @@ export const saveMinisterIssues = (planId, ministerIssues, newPastures) => {
     }),
     {}
   )
-  console.log(pastureMap)
 
   return Promise.all(
     ministerIssues.map(async issue => {

--- a/src/components/rangeUsePlanPage/index.js
+++ b/src/components/rangeUsePlanPage/index.js
@@ -41,6 +41,16 @@ import { useToast } from '../../providers/ToastProvider'
 import { useReferences } from '../../providers/ReferencesProvider'
 import RUPSchema from './schema'
 import OnSubmitValidationError from '../common/form/OnSubmitValidationError'
+import {
+  saveGrazingSchedules,
+  saveInvasivePlantChecklist,
+  saveManagementConsiderations,
+  saveAdditionalRequirements,
+  saveMinisterIssues,
+  getPlan,
+  savePastures,
+  savePlantCommunities
+} from '../../api'
 
 const Base = ({
   user,
@@ -67,11 +77,9 @@ const Base = ({
     const planId = getPlanId()
 
     try {
-      const { data } = await axios.get(
-        API.GET_RUP(planId),
-        getAuthHeaderConfig()
-      )
-      setPlan(RUPSchema.cast(data))
+      const plan = await getPlan(planId)
+
+      setPlan(RUPSchema.cast(plan))
     } catch (e) {
       setError(e)
     }
@@ -105,237 +113,23 @@ const Base = ({
       // Update Plan
       await axios.put(API.UPDATE_RUP(plan.id), plan, config)
 
-      const pasturesData = await Promise.all(
-        pastures.map(pasture => {
-          if (Number.isInteger(pasture.id)) {
-            return axios.put(
-              API.UPDATE_RUP_PASTURE(plan.id, pasture.id),
-              pasture,
-              config
-            )
-          } else {
-            const { id, ...values } = pasture
-            return axios.post(API.CREATE_RUP_PASTURE(plan.id), values, config)
-          }
-        })
-      )
-
-      const newPastures = pasturesData.map(p => p.data)
-      const newPasturesMap = newPastures.reduce(
-        (acc, newPasture, i) => ({
-          ...acc,
-          [pastures[i].id]: newPasture.id
-        }),
-        {}
-      )
+      const newPastures = await savePastures(plan.id, pastures)
 
       await Promise.all(
-        pastures.map((pasture, pastureIndex) =>
-          Promise.all(
-            pasture.plantCommunities.map(async plantCommunity => {
-              let { id: communityId, ...values } = plantCommunity
-              const pastureId = newPastures[pastureIndex].id
-              if (uuid.isUUID(communityId)) {
-                communityId = (await axios.post(
-                  API.CREATE_RUP_PLANT_COMMUNITY(plan.id, pastureId),
-                  values,
-                  config
-                )).data.id
-              }
-
-              await Promise.all(
-                plantCommunity.plantCommunityActions.map(action => {
-                  let { id: actionId, ...values } = action
-                  if (uuid.isUUID(actionId)) {
-                    return axios.post(
-                      API.CREATE_RUP_PLANT_COMMUNITY_ACTION(
-                        plan.id,
-                        pastureId,
-                        communityId
-                      ),
-                      values,
-                      config
-                    )
-                  }
-                })
-              )
-
-              await Promise.all(
-                plantCommunity.indicatorPlants.map(plant => {
-                  let { id: plantId, ...values } = plant
-                  if (uuid.isUUID(plantId)) {
-                    return axios.post(
-                      API.CREATE_RUP_INDICATOR_PLANT(
-                        plan.id,
-                        pastureId,
-                        communityId
-                      ),
-                      values,
-                      config
-                    )
-                  }
-                })
-              )
-
-              await Promise.all(
-                plantCommunity.monitoringAreas.map(area => {
-                  let { id: areaId, ...values } = area
-                  if (uuid.isUUID(areaId)) {
-                    return axios.post(
-                      API.CREATE_RUP_MONITERING_AREA(
-                        plan.id,
-                        pastureId,
-                        communityId
-                      ),
-                      values,
-                      config
-                    )
-                  }
-                })
-              )
-            })
-          )
-        )
-      )
-
-      // Update Grazing Schedules
-      await Promise.all(
-        grazingSchedules.map(schedule => {
-          if (uuid.isUUID(schedule.id)) {
-            const { id, ...grazingSchedule } = schedule
-            return axios.post(
-              API.CREATE_RUP_GRAZING_SCHEDULE(plan.id),
-              { ...grazingSchedule, plan_id: plan.id },
-              config
-            )
-          } else {
-            return axios.put(
-              API.UPDATE_RUP_GRAZING_SCHEDULE(plan.id, schedule.id),
-              { ...schedule },
-              config
-            )
-          }
-        })
-      )
-
-      if (invasivePlantChecklist && invasivePlantChecklist.id) {
-        await axios.put(
-          API.UPDATE_RUP_INVASIVE_PLANT_CHECKLIST(
+        newPastures.map(async pasture => {
+          await savePlantCommunities(
             plan.id,
-            invasivePlantChecklist.id
-          ),
-          invasivePlantChecklist,
-          config
-        )
-      } else {
-        const { id, ...values } = invasivePlantChecklist
-        await axios.post(
-          API.CREATE_RUP_INVASIVE_PLANT_CHECKLIST(plan.id),
-          values,
-          config
-        )
-      }
-
-      await Promise.all(
-        managementConsiderations.map(consideration => {
-          if (uuid.isUUID(consideration.id)) {
-            const { id, ...values } = consideration
-            return axios.post(
-              API.CREATE_RUP_MANAGEMENT_CONSIDERATION(plan.id),
-              values,
-              config
-            )
-          } else {
-            return axios.put(
-              API.UPDATE_RUP_MANAGEMENT_CONSIDERATION(
-                plan.id,
-                consideration.id
-              ),
-              consideration,
-              config
-            )
-          }
+            pasture.id,
+            pasture.plantCommunities
+          )
         })
       )
 
-      await Promise.all(
-        ministerIssues.map(async issue => {
-          // Create new Minister Issues/Actions because they don't exist on the
-          // server yet
-          const { id, ...issueBody } = issue
-
-          if (uuid.isUUID(issue.id)) {
-            const { data: newIssue } = await axios.post(
-              API.CREATE_RUP_MINISTER_ISSUE(plan.id),
-              {
-                ...issueBody,
-                pastures: issueBody.pastures.map(p => newPasturesMap[p])
-              },
-              config
-            )
-
-            await Promise.all(
-              issue.ministerIssueActions.map(action => {
-                const { id, ...actionBody } = action
-
-                return axios.post(
-                  API.CREATE_RUP_MINISTER_ISSUE_ACTION(plan.id, newIssue.id),
-                  actionBody,
-                  config
-                )
-              })
-            )
-          } else {
-            await axios.put(
-              API.UPDATE_RUP_MINISTER_ISSUE(plan.id, issue.id),
-              {
-                ...issueBody,
-                pastures: issueBody.pastures.map(p => newPasturesMap[p])
-              },
-              config
-            )
-
-            const actions = issue.ministerIssueActions
-
-            await Promise.all(
-              actions.map(action => {
-                const { id, ...actionBody } = action
-                if (uuid.isUUID(action.id)) {
-                  return axios.post(
-                    API.CREATE_RUP_MINISTER_ISSUE_ACTION(plan.id, issue.id),
-                    actionBody,
-                    config
-                  )
-                }
-                return axios.put(
-                  API.UPDATE_RUP_MINISTER_ISSUE_ACTION(
-                    plan.id,
-                    issue.id,
-                    action.id
-                  ),
-                  actionBody,
-                  config
-                )
-              })
-            )
-          }
-        })
-      )
-
-      await Promise.all(
-        additionalRequirements.map(requirement => {
-          if (uuid.isUUID(requirement.id)) {
-            const { id, ...values } = requirement
-            return axios.post(
-              API.CREATE_RUP_ADDITIONAL_REQUIREMENT(plan.id),
-              values,
-              config
-            )
-          }
-
-          return Promise.resolve()
-        })
-      )
+      await saveGrazingSchedules(plan.id, grazingSchedules)
+      await saveInvasivePlantChecklist(plan.id, invasivePlantChecklist)
+      await saveManagementConsiderations(plan.id, managementConsiderations)
+      await saveMinisterIssues(plan.id, ministerIssues, newPastures)
+      await saveAdditionalRequirements(plan.id, additionalRequirements)
 
       formik.setSubmitting(false)
       successToast('Successfully saved draft')


### PR DESCRIPTION
Before, all the saving logic for the data in plans was directly in the `onSubmit` handler of the form. I've broken them out into a separate file, cleaning up the submit handler. 

Resolves #212 