### PR TITLE
Better "other" selection for dropdowns

### DIFF
--- a/src/components/common/form/DayMonthPicker.js
+++ b/src/components/common/form/DayMonthPicker.js
@@ -16,7 +16,7 @@ import {
 
 const DayMonthPicker = connect(
   ({ dayName, monthName, label, formik, dateFormat, ...props }) => {
-    const [open, setOpen] = useState(true)
+    const [open, setOpen] = useState(false)
     const [currentMonth, setCurrentMonth] = useState(0)
 
     const previousMonth = () =>

--- a/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlant.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlant.js
@@ -1,0 +1,115 @@
+import React, { useState } from 'react'
+import PermissionsField, { IfEditable } from '../../common/PermissionsField'
+import { STUBBLE_HEIGHT } from '../../../constants/fields'
+import { Dropdown, Icon, Grid } from 'semantic-ui-react'
+import { useReferences } from '../../../providers/ReferencesProvider'
+import { REFERENCE_KEY } from '../../../constants/variables'
+import { Dropdown as FormikDropdown, Form } from 'formik-semantic-ui'
+import DecimalField from '../../common/form/DecimalField'
+
+const IndicatorPlant = ({ plant, namespace, valueType, onDelete, formik }) => {
+  const references = useReferences()
+
+  const species =
+    references[REFERENCE_KEY.PLANT_SPECIES].filter(s => !s.isShrubUse) || []
+
+  const otherSpecies = species.find(s => s.name === 'Other')
+  const [otherType, setOtherType] = useState({
+    key: otherSpecies.id,
+    value: otherSpecies.id,
+    text: plant.name || otherSpecies.name
+  })
+
+  const options = species
+    .map(species => ({
+      key: species.id,
+      value: species.id,
+      text: species.name
+    }))
+    .filter(o => o.text !== 'Other')
+    .concat(otherType)
+
+  return (
+    <Grid key={plant.id}>
+      <Grid.Column mobile="15">
+        <Form.Group widths="equal" style={{ margin: 0 }}>
+          <PermissionsField
+            permission={STUBBLE_HEIGHT.INDICATOR_PLANTS}
+            name={`${namespace}.plantSpeciesId`}
+            component={FormikDropdown}
+            placeholder="Indicator Plant"
+            options={options}
+            displayValue={
+              options.find(o => o.key === plant.plantSpeciesId)
+                ? options.find(o => o.key === plant.plantSpeciesId).text
+                : ''
+            }
+            inputProps={{
+              search: true,
+              allowAdditions: true,
+              onAddItem: (e, { value }) => {
+                setOtherType({
+                  ...otherType,
+                  text: value
+                })
+
+                formik.setFieldValue(
+                  `${namespace}.plantSpeciesId`,
+                  otherType.value
+                )
+                formik.setFieldValue(`${namespace}.name`, value)
+              },
+              onChange: (e, { value }) => {
+                if (typeof value !== 'string') {
+                  const plantValue = species.find(s => s.id === value)[
+                    valueType
+                  ]
+                  if (plantValue) {
+                    formik.setFieldValue(`${namespace}.value`, plantValue)
+                  }
+                }
+              },
+              fluid: true
+            }}
+          />
+
+          <PermissionsField
+            permission={STUBBLE_HEIGHT.INDICATOR_PLANTS}
+            name={`${namespace}.value`}
+            component={DecimalField}
+            displayValue={plant.value}
+          />
+        </Form.Group>
+      </Grid.Column>
+
+      <Grid.Column mobile="1" verticalAlign="middle">
+        {!Number.isInteger(plant.id) && (
+          <IfEditable permission={STUBBLE_HEIGHT.INDICATOR_PLANTS}>
+            <Dropdown
+              trigger={<Icon name="ellipsis vertical" />}
+              options={[
+                {
+                  key: 'delete',
+                  value: 'delete',
+                  text: 'Delete'
+                }
+              ]}
+              style={{ display: 'flex', alignItems: 'center' }}
+              icon={null}
+              pointing="right"
+              onClick={e => e.stopPropagation()}
+              onChange={(e, { value }) => {
+                if (value === 'delete') {
+                  onDelete()
+                }
+              }}
+              selectOnBlur={false}
+            />
+          </IfEditable>
+        )}
+      </Grid.Column>
+    </Grid>
+  )
+}
+
+export default IndicatorPlant

--- a/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlant.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlant.js
@@ -47,6 +47,7 @@ const IndicatorPlant = ({ plant, namespace, valueType, onDelete, formik }) => {
             inputProps={{
               search: true,
               allowAdditions: true,
+              additionLabel: 'Other: ',
               onAddItem: (e, { value }) => {
                 setOtherType({
                   ...otherType,

--- a/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.js
@@ -2,14 +2,11 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import uuid from 'uuid-v4'
 import { NOT_PROVIDED } from '../../../constants/strings'
-import PermissionsField, { IfEditable } from '../../common/PermissionsField'
+import { IfEditable } from '../../common/PermissionsField'
 import { STUBBLE_HEIGHT } from '../../../constants/fields'
-import { Button, Confirm, Dropdown, Icon, Grid } from 'semantic-ui-react'
-import { useReferences } from '../../../providers/ReferencesProvider'
-import { REFERENCE_KEY } from '../../../constants/variables'
-import { Input, Dropdown as FormikDropdown, Form } from 'formik-semantic-ui'
+import { Button, Confirm } from 'semantic-ui-react'
 import { FieldArray, connect } from 'formik'
-import DecimalField from '../../common/form/DecimalField'
+import IndicatorPlant from './IndicatorPlant'
 
 const IndicatorPlantsForm = ({
   indicatorPlants,
@@ -19,17 +16,6 @@ const IndicatorPlantsForm = ({
   namespace,
   formik
 }) => {
-  const references = useReferences()
-
-  const species =
-    references[REFERENCE_KEY.PLANT_SPECIES].filter(s => !s.isShrubUse) || []
-
-  const options = species.map(species => ({
-    key: species.id,
-    value: species.id,
-    text: species.name
-  }))
-
   const [toRemove, setToRemove] = useState()
   const [removeDialogOpen, setDialogOpen] = useState(false)
 
@@ -59,94 +45,17 @@ const IndicatorPlantsForm = ({
             {indicatorPlants.map(
               (plant, index) =>
                 plant.criteria === criteria && (
-                  <Grid key={plant.id}>
-                    <Grid.Column mobile="8">
-                      <Form.Group widths="equal" style={{ margin: 0 }}>
-                        <PermissionsField
-                          permission={STUBBLE_HEIGHT.INDICATOR_PLANTS}
-                          name={`${namespace}.indicatorPlants.${index}.plantSpeciesId`}
-                          component={FormikDropdown}
-                          placeholder="Indicator Plant"
-                          options={options}
-                          displayValue={
-                            plant.plantSpeciesId
-                              ? options.find(
-                                  o => o.key === plant.plantSpeciesId
-                                ).text
-                              : ''
-                          }
-                          inputProps={{
-                            onChange: (e, { value }) => {
-                              const plantValue = species.find(
-                                s => s.id === value
-                              )[valueType]
-                              if (plantValue) {
-                                formik.setFieldValue(
-                                  `${namespace}.indicatorPlants.${index}.value`,
-                                  plantValue
-                                )
-                              }
-                            },
-                            fluid: true
-                          }}
-                        />
-
-                        {options.find(o => o.key === plant.plantSpeciesId) &&
-                          options.find(o => o.key === plant.plantSpeciesId)
-                            .text === 'Other' && (
-                            <PermissionsField
-                              permission={STUBBLE_HEIGHT.INDICATOR_PLANTS}
-                              name={`${namespace}.indicatorPlants.${index}.name`}
-                              component={Input}
-                              displayValue={plant.name}
-                              inputProps={{
-                                fluid: true,
-                                placeholder: 'Other indicator plant'
-                              }}
-                            />
-                          )}
-                      </Form.Group>
-                    </Grid.Column>
-
-                    <Grid.Column mobile="7">
-                      <Form.Group widths="equal" style={{ margin: 0 }}>
-                        <PermissionsField
-                          permission={STUBBLE_HEIGHT.INDICATOR_PLANTS}
-                          name={`${namespace}.indicatorPlants.${index}.value`}
-                          component={DecimalField}
-                          displayValue={plant.value}
-                        />
-                      </Form.Group>
-                    </Grid.Column>
-                    <Grid.Column mobile="1" verticalAlign="middle">
-                      {!Number.isInteger(plant.id) && (
-                        <IfEditable
-                          permission={STUBBLE_HEIGHT.INDICATOR_PLANTS}>
-                          <Dropdown
-                            trigger={<Icon name="ellipsis vertical" />}
-                            options={[
-                              {
-                                key: 'delete',
-                                value: 'delete',
-                                text: 'Delete'
-                              }
-                            ]}
-                            style={{ display: 'flex', alignItems: 'center' }}
-                            icon={null}
-                            pointing="right"
-                            onClick={e => e.stopPropagation()}
-                            onChange={(e, { value }) => {
-                              if (value === 'delete') {
-                                setToRemove(index)
-                                setDialogOpen(true)
-                              }
-                            }}
-                            selectOnBlur={false}
-                          />
-                        </IfEditable>
-                      )}
-                    </Grid.Column>
-                  </Grid>
+                  <IndicatorPlant
+                    key={`indicatorPlant_${plant.id}`}
+                    namespace={`${namespace}.indicatorPlants.${index}`}
+                    plant={plant}
+                    formik={formik}
+                    valueType={valueType}
+                    onDelete={() => {
+                      setToRemove(index)
+                      setDialogOpen(true)
+                    }}
+                  />
                 )
             )}
 
@@ -192,7 +101,7 @@ IndicatorPlantsForm.propTypes = {
   indicatorPlants: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-      plantSpeciesId: PropTypes.number,
+      plantSpeciesId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       criteria: PropTypes.string.isRequired
     })

--- a/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.story.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlantsForm.story.js
@@ -22,6 +22,13 @@ const indicatorPlants = [
     value: 2.5,
     plantSpeciesId: 56,
     criteria: 'rangeReadiness'
+  },
+  {
+    id: 3,
+    value: 2.5,
+    plantSpeciesId: 56,
+    criteria: 'stubbleHeight',
+    name: 'My plant'
   }
 ]
 

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityAction.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityAction.js
@@ -1,0 +1,174 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'formik'
+import { Form, Icon, Dropdown as PlainDropdown, Grid } from 'semantic-ui-react'
+import { useReferences } from '../../../providers/ReferencesProvider'
+import { REFERENCE_KEY } from '../../../constants/variables'
+import PermissionsField, { IfEditable } from '../../common/PermissionsField'
+import { PLANT_COMMUNITY } from '../../../constants/fields'
+import { Dropdown, TextArea } from 'formik-semantic-ui'
+import DayMonthPicker from '../../common/form/DayMonthPicker'
+import moment from 'moment'
+
+const PlantCommunityAction = ({ action, namespace, onDelete, formik }) => {
+  const references = useReferences()
+  const actionTypes = references[REFERENCE_KEY.PLANT_COMMUNITY_ACTION_TYPE]
+
+  const otherType = actionTypes.find(type => type.name === 'Other')
+  const [otherOption, setOtherOption] = useState({
+    key: otherType.id,
+    value: otherType.id,
+    text: action.name || otherType.name
+  })
+
+  const actionOptions = actionTypes
+    .map(type => ({
+      key: type.id,
+      value: type.id,
+      text: type.name
+    }))
+    .filter(o => o.text !== 'Other')
+    .concat(otherOption)
+
+  return (
+    <Grid>
+      <Grid.Column width="4">
+        <PermissionsField
+          name={`${namespace}.actionTypeId`}
+          permission={PLANT_COMMUNITY.ACTIONS.NAME}
+          component={Dropdown}
+          options={actionOptions}
+          displayValue={
+            actionOptions.find(option => option.value === action.actionTypeId)
+              ? actionOptions.find(
+                  option => option.value === action.actionTypeId
+                ).text
+              : ''
+          }
+          label="Action"
+          fieldProps={{
+            required: true
+          }}
+          inputProps={{
+            allowAdditions: true,
+            search: true,
+            fluid: true,
+            additionLabel: 'Other: ',
+            onAddItem: (e, { value }) => {
+              setOtherOption({
+                ...otherOption,
+                text: value
+              })
+
+              formik.setFieldValue(
+                `${namespace}.actionTypeId`,
+                otherOption.value
+              )
+              formik.setFieldValue(`${namespace}.name`, value)
+            }
+          }}
+        />
+
+        {actionOptions.find(option => option.value === action.actionTypeId) &&
+          actionOptions.find(option => option.value === action.actionTypeId)
+            .text === 'Other' && (
+            <PermissionsField
+              name={`${namespace}.name`}
+              permission={PLANT_COMMUNITY.ACTIONS.NAME}
+              displayValue={action.name}
+              label="Other name"
+              fieldProps={{
+                style: { marginTop: '-4px' },
+                required: true
+              }}
+              inputProps={{
+                fluid: true
+              }}
+            />
+          )}
+      </Grid.Column>
+
+      <Grid.Column width="11">
+        <PermissionsField
+          name={`${namespace}.details`}
+          permission={PLANT_COMMUNITY.ACTIONS.DETAIL}
+          displayValue={action.details}
+          component={TextArea}
+          label="Details"
+          fieldProps={{
+            required: true
+          }}
+          inputProps={{
+            rows: 5
+          }}
+        />
+
+        {actionOptions.find(option => option.value === action.actionTypeId) &&
+          actionOptions.find(option => option.value === action.actionTypeId)
+            .text === 'Timing' && (
+            <Form.Group widths="equal">
+              <PermissionsField
+                monthName={`${namespace}.noGrazeStartMonth`}
+                dayName={`${namespace}.noGrazeStartDay`}
+                permission={PLANT_COMMUNITY.ACTIONS.NO_GRAZING_PERIOD}
+                displayValue={moment(
+                  `${action.noGrazeStartMonth} ${action.noGrazeStartDay}`,
+                  'MM DD'
+                ).format('MMMM Do')}
+                component={DayMonthPicker}
+                label="No Graze Start"
+                fluid
+              />
+
+              <PermissionsField
+                monthName={`${namespace}.noGrazeEndMonth`}
+                dayName={`${namespace}.noGrazeEndDay`}
+                permission={PLANT_COMMUNITY.ACTIONS.NO_GRAZING_PERIOD}
+                displayValue={moment(
+                  `${action.noGrazeEndMonth} ${action.noGrazeEndDay}`,
+                  'MM DD'
+                ).format('MMMM Do')}
+                component={DayMonthPicker}
+                label="No Graze End"
+                fluid
+              />
+            </Form.Group>
+          )}
+      </Grid.Column>
+
+      <IfEditable permission={PLANT_COMMUNITY.ACTIONS.NAME}>
+        <Grid.Column width="1" verticalAlign="middle">
+          <PlainDropdown
+            trigger={<Icon name="ellipsis vertical" />}
+            options={[
+              {
+                key: 'delete',
+                value: 'delete',
+                text: 'Delete'
+              }
+            ]}
+            style={{ display: 'flex', alignItems: 'center' }}
+            icon={null}
+            pointing="right"
+            onClick={e => e.stopPropagation()}
+            onChange={(e, { value }) => {
+              if (value === 'delete') {
+                onDelete()
+              }
+            }}
+            selectOnBlur={false}
+          />
+        </Grid.Column>
+      </IfEditable>
+    </Grid>
+  )
+}
+
+PlantCommunityAction.propTypes = {
+  action: PropTypes.object.isRequired,
+  namespace: PropTypes.string.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  formik: PropTypes.object.isRequired
+}
+
+export default connect(PlantCommunityAction)

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityAction.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityAction.js
@@ -68,24 +68,6 @@ const PlantCommunityAction = ({ action, namespace, onDelete, formik }) => {
             }
           }}
         />
-
-        {actionOptions.find(option => option.value === action.actionTypeId) &&
-          actionOptions.find(option => option.value === action.actionTypeId)
-            .text === 'Other' && (
-            <PermissionsField
-              name={`${namespace}.name`}
-              permission={PLANT_COMMUNITY.ACTIONS.NAME}
-              displayValue={action.name}
-              label="Other name"
-              fieldProps={{
-                style: { marginTop: '-4px' },
-                required: true
-              }}
-              inputProps={{
-                fluid: true
-              }}
-            />
-          )}
       </Grid.Column>
 
       <Grid.Column width="11">

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
@@ -2,36 +2,11 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { FieldArray, connect } from 'formik'
 import uuid from 'uuid-v4'
-import {
-  Button,
-  Form,
-  Confirm,
-  Icon,
-  Dropdown as PlainDropdown,
-  Grid
-} from 'semantic-ui-react'
-import { useReferences } from '../../../providers/ReferencesProvider'
-import { REFERENCE_KEY } from '../../../constants/variables'
-import PermissionsField, { IfEditable } from '../../common/PermissionsField'
-import { PLANT_COMMUNITY } from '../../../constants/fields'
-import { Dropdown, TextArea } from 'formik-semantic-ui'
-import DayMonthPicker from '../../common/form/DayMonthPicker'
-import moment from 'moment'
+import { Button, Confirm } from 'semantic-ui-react'
+import PlantCommunityAction from './PlantCommunityAction'
 
 const PlantCommunityActionsBox = ({ actions, namespace }) => {
-  const [otherOptions, setOtherOptions] = useState([])
   const [toRemove, setToRemove] = useState(null)
-
-  const references = useReferences()
-  const actionTypes = references[REFERENCE_KEY.PLANT_COMMUNITY_ACTION_TYPE]
-
-  const actionOptions = actionTypes
-    .map(type => ({
-      key: type.id,
-      value: type.id,
-      text: type.name
-    }))
-    .concat(otherOptions)
 
   return (
     <FieldArray
@@ -39,141 +14,14 @@ const PlantCommunityActionsBox = ({ actions, namespace }) => {
       render={({ push, remove }) => (
         <>
           {actions.map((action, index) => (
-            <Grid key={action.id || `action${index}`}>
-              <Grid.Column width="4">
-                <PermissionsField
-                  name={`${namespace}.plantCommunityActions.${index}.actionTypeId`}
-                  permission={PLANT_COMMUNITY.ACTIONS.NAME}
-                  component={Dropdown}
-                  options={actionOptions}
-                  displayValue={
-                    actionOptions.find(
-                      option => option.value === action.actionTypeId
-                    )
-                      ? actionOptions.find(
-                          option => option.value === action.actionTypeId
-                        ).text
-                      : ''
-                  }
-                  label="Action"
-                  fieldProps={{
-                    required: true
-                  }}
-                  inputProps={{
-                    allowAdditions: true,
-                    search: true,
-                    fluid: true,
-                    onAddItem: (e, { value }) => {
-                      setOtherOptions([
-                        ...otherOptions,
-                        {
-                          key: value,
-                          value: value,
-                          text: value
-                        }
-                      ])
-                    }
-                  }}
-                />
-
-                {actionOptions.find(
-                  option => option.value === action.actionTypeId
-                ) &&
-                  actionOptions.find(
-                    option => option.value === action.actionTypeId
-                  ).text === 'Other' && (
-                    <PermissionsField
-                      name={`${namespace}.plantCommunityActions.${index}.name`}
-                      permission={PLANT_COMMUNITY.ACTIONS.NAME}
-                      displayValue={action.name}
-                      label="Other name"
-                      fieldProps={{
-                        style: { marginTop: '-4px' },
-                        required: true
-                      }}
-                      inputProps={{
-                        fluid: true
-                      }}
-                    />
-                  )}
-              </Grid.Column>
-
-              <Grid.Column width="11">
-                <PermissionsField
-                  name={`${namespace}.plantCommunityActions.${index}.details`}
-                  permission={PLANT_COMMUNITY.ACTIONS.DETAIL}
-                  displayValue={action.details}
-                  component={TextArea}
-                  label="Details"
-                  fieldProps={{
-                    required: true
-                  }}
-                  inputProps={{
-                    rows: 5
-                  }}
-                />
-
-                {actionOptions.find(
-                  option => option.value === action.actionTypeId
-                ) &&
-                  actionOptions.find(
-                    option => option.value === action.actionTypeId
-                  ).text === 'Timing' && (
-                    <Form.Group widths="equal">
-                      <PermissionsField
-                        monthName={`${namespace}.plantCommunityActions.${index}.noGrazeStartMonth`}
-                        dayName={`${namespace}.plantCommunityActions.${index}.noGrazeStartDay`}
-                        permission={PLANT_COMMUNITY.ACTIONS.NO_GRAZING_PERIOD}
-                        displayValue={moment(
-                          `${action.noGrazeStartMonth} ${action.noGrazeStartDay}`,
-                          'MM DD'
-                        ).format('MMMM Do')}
-                        component={DayMonthPicker}
-                        label="No Graze Start"
-                        fluid
-                      />
-
-                      <PermissionsField
-                        monthName={`${namespace}.plantCommunityActions.${index}.noGrazeEndMonth`}
-                        dayName={`${namespace}.plantCommunityActions.${index}.noGrazeEndDay`}
-                        permission={PLANT_COMMUNITY.ACTIONS.NO_GRAZING_PERIOD}
-                        displayValue={moment(
-                          `${action.noGrazeEndMonth} ${action.noGrazeEndDay}`,
-                          'MM DD'
-                        ).format('MMMM Do')}
-                        component={DayMonthPicker}
-                        label="No Graze End"
-                        fluid
-                      />
-                    </Form.Group>
-                  )}
-              </Grid.Column>
-
-              <IfEditable permission={PLANT_COMMUNITY.ACTIONS.NAME}>
-                <Grid.Column width="1" verticalAlign="middle">
-                  <PlainDropdown
-                    trigger={<Icon name="ellipsis vertical" />}
-                    options={[
-                      {
-                        key: 'delete',
-                        value: 'delete',
-                        text: 'Delete'
-                      }
-                    ]}
-                    style={{ display: 'flex', alignItems: 'center' }}
-                    icon={null}
-                    pointing="right"
-                    onClick={e => e.stopPropagation()}
-                    onChange={(e, { value }) => {
-                      if (value === 'delete') {
-                        setToRemove(index)
-                      }
-                    }}
-                    selectOnBlur={false}
-                  />
-                </Grid.Column>
-              </IfEditable>
-            </Grid>
+            <PlantCommunityAction
+              action={action}
+              key={action.id || `action${index}`}
+              namespace={`${namespace}.plantCommunityActions.${index}`}
+              onDelete={() => {
+                setToRemove(index)
+              }}
+            />
           ))}
           <Confirm
             open={toRemove !== null}

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/RangeReadinessBox.js
@@ -60,14 +60,7 @@ const RangeReadinessBox = ({ plantCommunity, namespace }) => {
 
 RangeReadinessBox.propTypes = {
   plantCommunity: PropTypes.shape({
-    indicatorPlants: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-          .isRequired,
-        plantSpeciesId: PropTypes.number,
-        value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-      })
-    )
+    indicatorPlants: PropTypes.arrayOf(PropTypes.object)
   }),
   namespace: PropTypes.string.isRequired
 }

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/ShrubUseBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/ShrubUseBox.js
@@ -29,14 +29,7 @@ const ShrubUseBox = ({ plantCommunity, namespace }) => {
 
 ShrubUseBox.propTypes = {
   plantCommunity: PropTypes.shape({
-    indicatorPlants: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-          .isRequired,
-        plantSpeciesId: PropTypes.number,
-        value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-      })
-    )
+    indicatorPlants: PropTypes.arrayOf(PropTypes.object)
   }),
   namespace: PropTypes.string.isRequired
 }

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/StubbleHeightBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/StubbleHeightBox.js
@@ -24,14 +24,7 @@ const StubbleHeightBox = ({ plantCommunity, namespace }) => {
 
 StubbleHeightBox.propTypes = {
   plantCommunity: PropTypes.shape({
-    indicatorPlants: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-          .isRequired,
-        plantSpeciesId: PropTypes.number,
-        value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-      })
-    )
+    indicatorPlants: PropTypes.arrayOf(PropTypes.object)
   }),
   namespace: PropTypes.string.isRequired
 }


### PR DESCRIPTION
Allows an "other" value to be provided right in the dropdown for indicator plants and plant community actions. Also adds a search feature.

Relates to #169 and #177 