### PR TITLE
Don't memoize GrazingScheduleEntryRow

### DIFF
--- a/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleEntryRow.js
+++ b/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleEntryRow.js
@@ -168,9 +168,4 @@ GrazingScheduleEntryRow.propTypes = {
   onCopy: PropTypes.func.isRequired
 }
 
-export default connect(
-  React.memo(
-    GrazingScheduleEntryRow,
-    (prevProps, nextProps) => prevProps.entry === nextProps.entry
-  )
-)
+export default connect(GrazingScheduleEntryRow)


### PR DESCRIPTION
Because of component memoization the grazing schedule wasn't updating it's calculations when fields in other sections were changes, like the value for PLD percent. I've unmemoized the component for now to resolve this.