### PR TITLE
Have PDF downloaded through URL, rather than displaying inline viewer

### DIFF
--- a/src/components/rangeUsePlanPage/DownloadPDFBtn.js
+++ b/src/components/rangeUsePlanPage/DownloadPDFBtn.js
@@ -20,6 +20,7 @@ const DownloadPDFBtn = ({ onClick, disabled }) => (
       inverted
       disabled={disabled}
       onClick={onClick}
+      type="button"
       icon="file pdf outline"
       style={{ marginRight: '0' }}
     />
@@ -29,6 +30,7 @@ const DownloadPDFBtn = ({ onClick, disabled }) => (
       inverted
       disabled={disabled}
       onClick={onClick}
+      type="button"
       style={{ marginRight: '0' }}>
       <Icon name="file pdf outline" />
       {DOWNLOAD_PDF}

--- a/src/components/rangeUsePlanPage/index.js
+++ b/src/components/rangeUsePlanPage/index.js
@@ -1,7 +1,8 @@
 import React, { Fragment, useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { Icon } from 'semantic-ui-react'
+import { Icon, Modal, Header, Button } from 'semantic-ui-react'
+import { Route } from 'react-router-dom'
 import { Loading, PrimaryButton } from '../common'
 import {
   planUpdated,
@@ -51,6 +52,7 @@ import {
   savePastures,
   savePlantCommunities
 } from '../../api'
+import PDFView from './pdf/PDFView'
 
 const Base = ({
   user,
@@ -187,6 +189,31 @@ const Base = ({
           />
         </div>
       )}
+
+      <Route
+        path={`${match.url}/export-pdf`}
+        render={() => {
+          const closePDFModal = () => history.push(match.url)
+          return (
+            <Modal
+              size="tiny"
+              open={true}
+              onClose={closePDFModal}
+              dimmer="blurring">
+              <Header content="Download PDF" icon="file pdf" />
+              <Modal.Content>
+                The PDF may take a few minutes to generate.
+              </Modal.Content>
+              <Modal.Actions>
+                <Button type="button" onClick={closePDFModal}>
+                  Close
+                </Button>
+                <PDFView match={match} />
+              </Modal.Actions>
+            </Modal>
+          )
+        }}
+      />
 
       {plan && (
         <Form

--- a/src/components/rangeUsePlanPage/pageForAH/index.js
+++ b/src/components/rangeUsePlanPage/pageForAH/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { PLAN_STATUS, REFERENCE_KEY } from '../../../constants/variables'
-import { RANGE_USE_PLAN, EXPORT_PDF } from '../../../constants/routes'
+import { RANGE_USE_PLAN } from '../../../constants/routes'
 import * as strings from '../../../constants/strings'
 import * as utils from '../../../utils'
 import { Status, Banner } from '../../common'
@@ -161,8 +161,8 @@ class PageForAH extends Component {
   }
 
   onViewPDFClicked = () => {
-    const { id: planId, agreementId } = this.props.plan || {}
-    window.open(`${EXPORT_PDF}/${agreementId}/${planId}`, '_blank')
+    const { id: planId } = this.props.plan || {}
+    this.props.history.push(`/range-use-plan/${planId}/export-pdf`)
   }
 
   openSubmissionModal = () => {

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -8,7 +8,6 @@ import BackBtn from '../BackBtn'
 import ContentsContainer from '../ContentsContainer'
 import UpdateStatusDropdown from './UpdateStatusDropdown'
 import StickyHeader from '../StickyHeader'
-import { EXPORT_PDF } from '../../../constants/routes'
 import Notifications from '../notifications'
 import { defaultProps, propTypes } from './props'
 import ActionBtns from '../ActionBtns'
@@ -126,8 +125,8 @@ class PageForStaff extends Component {
   }
 
   onViewPDFClicked = () => {
-    const { id: planId, agreementId } = this.props.plan || {}
-    window.open(`${EXPORT_PDF}/${agreementId}/${planId}`, '_blank')
+    const { id: planId } = this.props.plan || {}
+    this.props.history.push(`/range-use-plan/${planId}/export-pdf`)
   }
 
   openUpdateZoneModal = () => this.setState({ isUpdateZoneModalOpen: true })

--- a/src/components/rangeUsePlanPage/pdf/pdf/index.js
+++ b/src/components/rangeUsePlanPage/pdf/pdf/index.js
@@ -24,17 +24,21 @@ Font.register({
   ]
 })
 
-const RUPDocument = ({ plan }) => (
-  <Document title={`Range Use Plan - ${plan.agreement.id}`}>
-    <FrontPage plan={plan} />
-    <BasicInformation plan={plan} />
-    <Pastures plan={plan} />
-    <Schedules plan={plan} />
-    <MinisterIssues plan={plan} />
-    <InvasivePlants plan={plan} />
-    <AdditionalRequirements plan={plan} />
-    <ManagementConsiderations plan={plan} />
-  </Document>
-)
+const RUPDocument = ({ plan }) => {
+  if (!plan) return <Document />
+
+  return (
+    <Document title={`Range Use Plan - ${plan.agreement.id}`}>
+      <FrontPage plan={plan} />
+      <BasicInformation plan={plan} />
+      <Pastures plan={plan} />
+      <Schedules plan={plan} />
+      <MinisterIssues plan={plan} />
+      <InvasivePlants plan={plan} />
+      <AdditionalRequirements plan={plan} />
+      <ManagementConsiderations plan={plan} />
+    </Document>
+  )
+}
 
 export default RUPDocument

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -4,7 +4,7 @@ export const LOGOUT = '/logout'
 export const RETURN_PAGE = '/return-page'
 export const RANGE_USE_PLAN = '/range-use-plan'
 export const EXPORT_PDF = '/export-pdf'
-export const EXPORT_PDF_WITH_PARAM = '/export-pdf/:agreementId/:planId'
+export const EXPORT_PDF_WITH_PARAM = '/range-use-plan/:planId/export-pdf/'
 export const RANGE_USE_PLAN_WITH_PARAM = '/range-use-plan/:planId'
 
 export const MANAGE_ZONE = '/manage-zone'

--- a/src/utils/hooks/pdf.js
+++ b/src/utils/hooks/pdf.js
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react'
+import { pdf } from '@react-pdf/renderer'
+
+export const usePDF = (callback, deps = []) => {
+  const [pdfUrl, setPdfUrl] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const generatePdf = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      if (pdfUrl) {
+        URL.revokeObjectURL(pdfUrl)
+        setPdfUrl(null)
+      }
+
+      const doc = await callback()
+      const blob = await pdf(doc).toBlob()
+
+      setPdfUrl(URL.createObjectURL(blob))
+      setLoading(false)
+    } catch (e) {
+      setLoading(false)
+      setError(e)
+      console.error(e)
+    }
+  }
+  useEffect(() => {
+    generatePdf().catch(e => setError(e))
+  }, deps)
+
+  return [pdfUrl, loading, error, generatePdf]
+}


### PR DESCRIPTION
iOS doesn't support the inline PDF viewer used previously, so the implementation has been changed to simply render a link to the blob directly. This should have more cross-browser support. Also moved the PDF download to a modal rather than a separate page.