### PR TITLE
redirect to list page from range use plan

### DIFF
--- a/src/components/rangeUsePlanPage/BackBtn.js
+++ b/src/components/rangeUsePlanPage/BackBtn.js
@@ -19,29 +19,26 @@ const defaultProps = {
 
 class BackBtn extends Component {
   state = {
-    agreementSearchQuery: null
+    redirectPath: null
   }
 
   onBtnClick = e => {
     e.preventDefault()
     const { agreementSearchParams } = this.props
 
-    if (!agreementSearchParams) {
-      window.history.back()
-      return
-    }
-
     this.setState({
-      agreementSearchQuery: stringifyQuery(agreementSearchParams)
+      redirectPath: agreementSearchParams
+        ? `${HOME}?${stringifyQuery(agreementSearchParams)}`
+        : HOME
     })
   }
 
   render() {
     const { className } = this.props
-    const { agreementSearchQuery } = this.state
+    const { redirectPath } = this.state
 
-    if (agreementSearchQuery) {
-      return <Redirect push to={`${HOME}?${agreementSearchQuery}`} />
+    if (redirectPath) {
+      return <Redirect push to={redirectPath} />
     }
 
     return (


### PR DESCRIPTION
The "back" button beside the RAN number should redirect the user to the RUP list page, not act as a browser back button. 

Addresses issue #296 