### PR TITLE
Allow minister issue actions to be deleted and edited

### DIFF
--- a/src/components/rangeUsePlanPage/ministerIssues/MinisterIssueAction.js
+++ b/src/components/rangeUsePlanPage/ministerIssues/MinisterIssueAction.js
@@ -3,7 +3,7 @@ import uuid from 'uuid-v4'
 import { NO_DESCRIPTION } from '../../../constants/strings'
 import PermissionsField, { IfEditable } from '../../common/PermissionsField'
 import { MINISTER_ISSUES } from '../../../constants/fields'
-import { TextArea } from 'formik-semantic-ui'
+import { TextArea, Dropdown as FormikDropdown } from 'formik-semantic-ui'
 import { Form, Icon, Dropdown } from 'semantic-ui-react'
 import { useReferences } from '../../../providers/ReferencesProvider'
 import { REFERENCE_KEY } from '../../../constants/variables'
@@ -26,6 +26,12 @@ const MinisterIssueAction = ({
   const type = types.find(t => t.id === actionTypeId)
     ? types.find(t => t.id === actionTypeId).name
     : ''
+  const options = types.map(type => ({
+    key: type.id,
+    value: type.id,
+    text: type.name,
+    id: type.id
+  }))
 
   const isOtherType = type === 'Other'
   const isActionTypeTiming = type === 'Timing'
@@ -70,10 +76,25 @@ const MinisterIssueAction = ({
   return (
     <div className="rup__missue__action">
       <div className="rup__missue__action__dropdown-ellipsis-container">
-        <span className="rup__missue__action__type">
-          {type}
-          {isOtherType && other.name && ` (${other.name})`}
-        </span>
+        <Form.Group>
+          <PermissionsField
+            permission={MINISTER_ISSUES.ACTIONS.NAME}
+            name={`${namespace}.actionTypeId`}
+            displayValue={isOtherType ? 'Other:' : type}
+            component={FormikDropdown}
+            options={options}
+          />
+          {isOtherType && (
+            <PermissionsField
+              permission={MINISTER_ISSUES.ACTIONS.NAME}
+              name={`${namespace}.other`}
+              displayValue={other}
+              inputProps={{
+                placeholder: 'Other type'
+              }}
+            />
+          )}
+        </Form.Group>
 
         <IfEditable permission={MINISTER_ISSUES.ACTIONS.NAME}>
           <Dropdown

--- a/src/components/rangeUsePlanPage/ministerIssues/MinisterIssueAction.js
+++ b/src/components/rangeUsePlanPage/ministerIssues/MinisterIssueAction.js
@@ -1,9 +1,10 @@
 import React from 'react'
+import uuid from 'uuid-v4'
 import { NO_DESCRIPTION } from '../../../constants/strings'
-import PermissionsField from '../../common/PermissionsField'
+import PermissionsField, { IfEditable } from '../../common/PermissionsField'
 import { MINISTER_ISSUES } from '../../../constants/fields'
 import { TextArea } from 'formik-semantic-ui'
-import { Form } from 'semantic-ui-react'
+import { Form, Icon, Dropdown } from 'semantic-ui-react'
 import { useReferences } from '../../../providers/ReferencesProvider'
 import { REFERENCE_KEY } from '../../../constants/variables'
 import DayMonthPicker from '../../common/form/DayMonthPicker'
@@ -17,7 +18,9 @@ const MinisterIssueAction = ({
   noGrazeStartDay,
   noGrazeEndMonth,
   noGrazeEndDay,
-  namespace
+  namespace,
+  onDelete,
+  id
 }) => {
   const types = useReferences()[REFERENCE_KEY.MINISTER_ISSUE_ACTION_TYPE] || []
   const type = types.find(t => t.id === actionTypeId)
@@ -26,6 +29,15 @@ const MinisterIssueAction = ({
 
   const isOtherType = type === 'Other'
   const isActionTypeTiming = type === 'Timing'
+
+  const menuOptions = [
+    {
+      key: 'delete',
+      text: 'Delete',
+      onClick: uuid.isUUID(id) ? onDelete : null,
+      disabled: !uuid.isUUID(id)
+    }
+  ]
 
   const noGrazePeriod = (
     <Form.Group widths="equal">
@@ -57,10 +69,21 @@ const MinisterIssueAction = ({
 
   return (
     <div className="rup__missue__action">
-      <span className="rup__missue__action__type">
-        {type}
-        {isOtherType && other.name && ` (${other.name})`}
-      </span>
+      <div className="rup__missue__action__dropdown-ellipsis-container">
+        <span className="rup__missue__action__type">
+          {type}
+          {isOtherType && other.name && ` (${other.name})`}
+        </span>
+
+        <IfEditable permission={MINISTER_ISSUES.ACTIONS.NAME}>
+          <Dropdown
+            trigger={<Icon name="ellipsis vertical" />}
+            options={menuOptions}
+            icon={null}
+            pointing="right"
+          />
+        </IfEditable>
+      </div>
       <div className="rup__missue__action__detail">
         {isActionTypeTiming && noGrazePeriod}
 

--- a/src/components/rangeUsePlanPage/ministerIssues/MinisterIssueBox.js
+++ b/src/components/rangeUsePlanPage/ministerIssues/MinisterIssueBox.js
@@ -1,7 +1,7 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import uuid from 'uuid-v4'
-import { Icon } from 'semantic-ui-react'
+import { Icon, Confirm } from 'semantic-ui-react'
 import { CollapsibleBox } from '../../common'
 import { NOT_PROVIDED, ACTION_NOTE } from '../../../constants/strings'
 import { oxfordComma } from '../../../utils'
@@ -23,6 +23,8 @@ const MinisterIssueBox = ({
   namespace,
   formik
 }) => {
+  const [toRemove, setToRemove] = useState(null)
+
   const allPastures = getIn(formik.values, 'pastures') || []
   const pasturesOptions = allPastures.map((pasture, index) => ({
     value: pasture.id,
@@ -141,7 +143,7 @@ const MinisterIssueBox = ({
 
           <FieldArray
             name={`${namespace}.ministerIssueActions`}
-            render={({ push }) => (
+            render={({ push, remove }) => (
               <>
                 <div className="text-field__label" style={{ marginBottom: 10 }}>
                   Actions
@@ -167,6 +169,7 @@ const MinisterIssueBox = ({
                   <MinisterIssueAction
                     key={action.id}
                     namespace={`${namespace}.ministerIssueActions.${i}`}
+                    onDelete={() => setToRemove(i)}
                     {...action}
                   />
                 ))}
@@ -175,6 +178,16 @@ const MinisterIssueBox = ({
                     ? NOT_PROVIDED
                     : ACTION_NOTE}
                 </div>
+                <Confirm
+                  open={toRemove !== null}
+                  onCancel={() => {
+                    setToRemove(null)
+                  }}
+                  onConfirm={() => {
+                    remove(toRemove)
+                    setToRemove(null)
+                  }}
+                />
               </>
             )}
           />


### PR DESCRIPTION
Allows agreement holders to edit the minister issue action type after it has been created. Also lets them delete actions that have not been persisted yet.

Relates to #297 and #298