### PR TITLE
Handle if no pasture is set in grazing schedule entry row

### DIFF
--- a/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleEntryRow.js
+++ b/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleEntryRow.js
@@ -152,7 +152,7 @@ const GrazingScheduleEntryRow = ({
         <PermissionsField
           permission={SCHEDULE.GRACE_DAYS}
           name={`${namespace}.graceDays`}
-          displayValue={graceDays || pasture.graceDays}
+          displayValue={graceDays || (pasture ? pasture.graceDays : '')}
           inputProps={{
             type: 'number',
             fluid: true,


### PR DESCRIPTION
Fixes a bug where the "Add Row" button wouldn't work because it was attempting to pull the value for `graceDays` from the pasture, but there was no selected pasture yet.