### PR TITLE
Let persisted minister issue actions be deleted

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -336,3 +336,10 @@ const saveMonitoringAreas = (
     })
   )
 }
+
+export const deleteMinisterIssueAction = async (planId, issueId, actionId) => {
+  await axios.delete(
+    API.DELETE_RUP_MINISTER_ISSUE_ACTION(planId, issueId, actionId),
+    getAuthHeaderConfig()
+  )
+}

--- a/src/components/rangeUsePlanPage/ministerIssues/MinisterIssueAction.js
+++ b/src/components/rangeUsePlanPage/ministerIssues/MinisterIssueAction.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import uuid from 'uuid-v4'
 import { NO_DESCRIPTION } from '../../../constants/strings'
 import PermissionsField, { IfEditable } from '../../common/PermissionsField'
 import { MINISTER_ISSUES } from '../../../constants/fields'
@@ -19,8 +18,7 @@ const MinisterIssueAction = ({
   noGrazeEndMonth,
   noGrazeEndDay,
   namespace,
-  onDelete,
-  id
+  onDelete
 }) => {
   const types = useReferences()[REFERENCE_KEY.MINISTER_ISSUE_ACTION_TYPE] || []
   const type = types.find(t => t.id === actionTypeId)
@@ -40,8 +38,7 @@ const MinisterIssueAction = ({
     {
       key: 'delete',
       text: 'Delete',
-      onClick: uuid.isUUID(id) ? onDelete : null,
-      disabled: !uuid.isUUID(id)
+      onClick: onDelete
     }
   ]
 

--- a/src/components/rangeUsePlanPage/ministerIssues/MinisterIssueBox.js
+++ b/src/components/rangeUsePlanPage/ministerIssues/MinisterIssueBox.js
@@ -14,6 +14,7 @@ import { useReferences } from '../../../providers/ReferencesProvider'
 import { REFERENCE_KEY } from '../../../constants/variables'
 import AddMinisterIssueActionButton from './AddMinisterIssueActionButton'
 import moment from 'moment'
+import { deleteMinisterIssueAction } from '../../../api'
 
 const MinisterIssueBox = ({
   issue,
@@ -183,7 +184,17 @@ const MinisterIssueBox = ({
                   onCancel={() => {
                     setToRemove(null)
                   }}
-                  onConfirm={() => {
+                  onConfirm={async () => {
+                    const action = ministerIssueActions[toRemove]
+
+                    if (!uuid.isUUID(action.id)) {
+                      await deleteMinisterIssueAction(
+                        issue.planId,
+                        issue.id,
+                        action.id
+                      )
+                    }
+
                     remove(toRemove)
                     setToRemove(null)
                   }}


### PR DESCRIPTION
Didn't realize that there was already a delete endpoint for minister issue actions.

Relates to #307 
