### PR TITLE
Allow Management Considerations to be deleted

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -81,8 +81,8 @@ export const saveManagementConsiderations = (
     managementConsiderations.map(async consideration => {
       if (uuid.isUUID(consideration.id)) {
         const { id, ...values } = consideration
-        const { data } = await axios.put(
-          API.UPDATE_RUP_MANAGEMENT_CONSIDERATION(planId, consideration.id),
+        const { data } = await axios.post(
+          API.CREATE_RUP_MANAGEMENT_CONSIDERATION(planId),
           values,
           getAuthHeaderConfig()
         )
@@ -92,8 +92,8 @@ export const saveManagementConsiderations = (
           id: data.id
         }
       } else {
-        await axios.post(
-          API.CREATE_RUP_MANAGEMENT_CONSIDERATION(planId),
+        await axios.put(
+          API.UPDATE_RUP_MANAGEMENT_CONSIDERATION(planId, consideration.id),
           consideration,
           getAuthHeaderConfig()
         )

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -81,8 +81,8 @@ export const saveManagementConsiderations = (
     managementConsiderations.map(async consideration => {
       if (uuid.isUUID(consideration.id)) {
         const { id, ...values } = consideration
-        const { data } = await axios.post(
-          API.CREATE_RUP_MANAGEMENT_CONSIDERATION(planId),
+        const { data } = await axios.put(
+          API.UPDATE_RUP_MANAGEMENT_CONSIDERATION(planId, consideration.id),
           values,
           getAuthHeaderConfig()
         )
@@ -92,8 +92,8 @@ export const saveManagementConsiderations = (
           id: data.id
         }
       } else {
-        await axios.put(
-          API.UPDATE_RUP_MANAGEMENT_CONSIDERATION(planId, consideration.id),
+        await axios.post(
+          API.CREATE_RUP_MANAGEMENT_CONSIDERATION(planId),
           consideration,
           getAuthHeaderConfig()
         )
@@ -340,6 +340,16 @@ const saveMonitoringAreas = (
 export const deleteMinisterIssueAction = async (planId, issueId, actionId) => {
   await axios.delete(
     API.DELETE_RUP_MINISTER_ISSUE_ACTION(planId, issueId, actionId),
+    getAuthHeaderConfig()
+  )
+}
+
+export const deleteManagementConsideration = async (
+  planId,
+  considerationId
+) => {
+  await axios.delete(
+    API.DELETE_RUP_MANAGEMENT_CONSIDERATION(planId, considerationId),
     getAuthHeaderConfig()
   )
 }

--- a/src/components/rangeUsePlanPage/PlanForm.js
+++ b/src/components/rangeUsePlanPage/PlanForm.js
@@ -42,6 +42,7 @@ const PlanForm = ({ plan }) => {
       </Element>
       <Element name={ELEMENT_ID.MANAGEMENT_CONSIDERATIONS}>
         <ManagementConsiderations
+          planId={plan.id}
           managementConsiderations={plan.managementConsiderations}
         />
       </Element>

--- a/src/components/rangeUsePlanPage/managementConsiderations/ManagementConsiderationRow.js
+++ b/src/components/rangeUsePlanPage/managementConsiderations/ManagementConsiderationRow.js
@@ -8,7 +8,11 @@ import { TextArea } from 'formik-semantic-ui'
 import { Dropdown, Icon, Form } from 'semantic-ui-react'
 import { Dropdown as FormikDropdown } from 'formik-semantic-ui'
 
-const ManagementConsiderationRow = ({ namespace, managementConsideration }) => {
+const ManagementConsiderationRow = ({
+  namespace,
+  managementConsideration,
+  onDelete
+}) => {
   const { detail, url, considerationTypeId } = managementConsideration
   const references = useReferences()
   const considerTypes =
@@ -22,7 +26,7 @@ const ManagementConsiderationRow = ({ namespace, managementConsideration }) => {
     {
       key: 'delete',
       text: 'Delete',
-      onClick: () => {}
+      onClick: onDelete
     }
   ]
 

--- a/src/components/rangeUsePlanPage/managementConsiderations/index.js
+++ b/src/components/rangeUsePlanPage/managementConsiderations/index.js
@@ -77,6 +77,7 @@ const ManagementConsiderations = ({ planId, managementConsiderations }) => {
                   pointing="left"
                   onChange={(e, { value }) => {
                     push({
+                      id: uuid(),
                       considerationTypeId: value,
                       detail: '',
                       url: ''

--- a/src/components/rangeUsePlanPage/managementConsiderations/index.js
+++ b/src/components/rangeUsePlanPage/managementConsiderations/index.js
@@ -96,7 +96,7 @@ const ManagementConsiderations = ({ planId, managementConsiderations }) => {
             onConfirm={async () => {
               const consideration = managementConsiderations[toRemove]
 
-              if (uuid.isUUID(consideration.id)) {
+              if (!uuid.isUUID(consideration.id)) {
                 await deleteManagementConsideration(planId, consideration.id)
               }
 

--- a/src/components/rangeUsePlanPage/managementConsiderations/index.js
+++ b/src/components/rangeUsePlanPage/managementConsiderations/index.js
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import { Dropdown, Icon } from 'semantic-ui-react'
+import uuid from 'uuid-v4'
+import { Dropdown, Icon, Confirm } from 'semantic-ui-react'
 import { PrimaryButton } from '../../common'
 import { useReferences } from '../../../providers/ReferencesProvider'
 import { REFERENCE_KEY } from '../../../constants/variables'
@@ -8,8 +9,9 @@ import { FieldArray } from 'formik'
 import ManagementConsiderationRow from './ManagementConsiderationRow'
 import { IfEditable } from '../../common/PermissionsField'
 import { MANAGEMENT_CONSIDERATIONS } from '../../../constants/fields'
+import { deleteManagementConsideration } from '../../../api'
 
-const ManagementConsiderations = ({ managementConsiderations }) => {
+const ManagementConsiderations = ({ planId, managementConsiderations }) => {
   const references = useReferences()
   const considerTypes =
     references[REFERENCE_KEY.MANAGEMENT_CONSIDERATION_TYPE] || []
@@ -19,66 +21,90 @@ const ManagementConsiderations = ({ managementConsiderations }) => {
     text: ct.name
   }))
 
+  const [toRemove, setToRemove] = useState(null)
+
   return (
     <FieldArray
       name={`managementConsiderations`}
-      render={({ push }) => (
-        <div className="rup__m-considerations">
-          <div className="rup__content-title">Management Considerations</div>
-          <div className="rup__divider" />
+      render={({ push, remove }) => (
+        <>
+          <div className="rup__m-considerations">
+            <div className="rup__content-title">Management Considerations</div>
+            <div className="rup__divider" />
 
-          <div className="rup__m-considerations__note">
-            Content in this section is non-legal and is intended to provide
-            additional information about management within the agreement area.
-          </div>
-
-          <div className="rup__m-considerations__box">
-            <div className="rup__m-consideration__header">
-              <div>Considerations</div>
-              <div>Details</div>
+            <div className="rup__m-considerations__note">
+              Content in this section is non-legal and is intended to provide
+              additional information about management within the agreement area.
             </div>
 
-            {managementConsiderations.length === 0 ? (
-              <div className="rup__m-considerations__no-content">
-                No management considerations provided
+            <div className="rup__m-considerations__box">
+              <div className="rup__m-consideration__header">
+                <div>Considerations</div>
+                <div>Details</div>
               </div>
-            ) : (
-              managementConsiderations.map((managementConsideration, index) => (
-                <ManagementConsiderationRow
-                  key={managementConsideration.id}
-                  managementConsideration={managementConsideration}
-                  namespace={`managementConsiderations.${index}`}
-                />
-              ))
-            )}
 
-            <IfEditable permission={MANAGEMENT_CONSIDERATIONS.NAME}>
-              <Dropdown
-                trigger={
-                  <PrimaryButton
-                    inverted
-                    compact
-                    style={{ marginTop: '10px' }}
-                    type="button">
-                    <Icon name="add circle" />
-                    Add Consideration
-                  </PrimaryButton>
-                }
-                options={considerTypeOptions}
-                icon={null}
-                pointing="left"
-                onChange={(e, { value }) => {
-                  push({
-                    considerationTypeId: value,
-                    detail: '',
-                    url: ''
-                  })
-                }}
-                selectOnBlur={false}
-              />
-            </IfEditable>
+              {managementConsiderations.length === 0 ? (
+                <div className="rup__m-considerations__no-content">
+                  No management considerations provided
+                </div>
+              ) : (
+                managementConsiderations.map(
+                  (managementConsideration, index) => (
+                    <ManagementConsiderationRow
+                      key={index}
+                      managementConsideration={managementConsideration}
+                      namespace={`managementConsiderations.${index}`}
+                      onDelete={() => setToRemove(index)}
+                    />
+                  )
+                )
+              )}
+
+              <IfEditable permission={MANAGEMENT_CONSIDERATIONS.NAME}>
+                <Dropdown
+                  trigger={
+                    <PrimaryButton
+                      inverted
+                      compact
+                      style={{ marginTop: '10px' }}
+                      type="button">
+                      <Icon name="add circle" />
+                      Add Consideration
+                    </PrimaryButton>
+                  }
+                  options={considerTypeOptions}
+                  icon={null}
+                  pointing="left"
+                  onChange={(e, { value }) => {
+                    push({
+                      considerationTypeId: value,
+                      detail: '',
+                      url: ''
+                    })
+                  }}
+                  selectOnBlur={false}
+                />
+              </IfEditable>
+            </div>
           </div>
-        </div>
+
+          <Confirm
+            open={toRemove !== null}
+            onCancel={() => {
+              setToRemove(null)
+            }}
+            onConfirm={async () => {
+              const consideration = managementConsiderations[toRemove]
+
+              if (uuid.isUUID(consideration.id)) {
+                await deleteManagementConsideration(planId, consideration.id)
+              }
+
+              remove(toRemove)
+              setToRemove(null)
+            }}
+          />
+        </>
       )}
     />
   )


### PR DESCRIPTION
@calebissharp, I'm sorry that this has your changes from #311. I was having trouble saving the form to test out the behaviour I was trying to add. Unfortunately, it didn't solve my issue. I eventually just resorted to using my own backend instance so I could create a clean environment. However, in that version the `ID`s are numeric, not UUIDs. Can you confirm that the `ID`s will indeed be UUIDs in prod?

I noticed in your implementation of the Minister Issue Actions (#305) you added a delete function to the `api/index.js` instead of using the `actionCreators` function that already exists. Is the goal to eventually move all the api calls to the `api/index.js`?

Resolves the issue #299 .