### PR TITLE
Remove extra argument to validation function called on submit

### DIFF
--- a/src/components/rangeUsePlanPage/pageForAH/index.js
+++ b/src/components/rangeUsePlanPage/pageForAH/index.js
@@ -140,18 +140,12 @@ class PageForAH extends Component {
   }
 
   validateRup = plan => {
-    const {
-      references,
-      agreement,
-      pasturesMap,
-      grazingSchedulesMap
-    } = this.props
+    const { references, agreement, pasturesMap } = this.props
     const usage = agreement && agreement.usage
     const livestockTypes = references[REFERENCE_KEY.LIVESTOCK_TYPE]
     const errors = utils.handleRupValidation(
       plan,
       pasturesMap,
-      grazingSchedulesMap,
       livestockTypes,
       usage
     )

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -104,18 +104,12 @@ class PageForStaff extends Component {
   }
 
   validateRup = plan => {
-    const {
-      references,
-      agreement,
-      pasturesMap,
-      grazingSchedulesMap
-    } = this.props
+    const { references, agreement, pasturesMap } = this.props
     const usage = agreement && agreement.usage
     const livestockTypes = references[REFERENCE_KEY.LIVESTOCK_TYPE]
     const errors = utils.handleRupValidation(
       plan,
       pasturesMap,
-      grazingSchedulesMap,
       livestockTypes,
       usage
     )


### PR DESCRIPTION
There was an extra `grazingSchedulesMap` argument being provided to the `handleRupValidation` function, which was causing errors. I've removed it from every place it is called.

Related to #309 and #310 
