### PR TITLE
Don't update confirmation if submitted for feedback

### DIFF
--- a/src/components/rangeUsePlanPage/pageForAH/SubmissionModal.js
+++ b/src/components/rangeUsePlanPage/pageForAH/SubmissionModal.js
@@ -82,12 +82,12 @@ class SubmissionModal extends Component {
       const isMinorAmendment = false
 
       if (status.id === 14) {
-      await updateRUPConfirmation(
-        plan,
-        currUserConfirmation.id,
-        confirmed,
-        isMinorAmendment
-      )
+        await updateRUPConfirmation(
+          plan,
+          currUserConfirmation.id,
+          confirmed,
+          isMinorAmendment
+        )
       }
       await fetchPlan()
       this.setState({ isSubmitting: false })

--- a/src/components/rangeUsePlanPage/pageForAH/SubmissionModal.js
+++ b/src/components/rangeUsePlanPage/pageForAH/SubmissionModal.js
@@ -81,12 +81,14 @@ class SubmissionModal extends Component {
       const confirmed = true
       const isMinorAmendment = false
 
+      if (status.id === 14) {
       await updateRUPConfirmation(
         plan,
         currUserConfirmation.id,
         confirmed,
         isMinorAmendment
       )
+      }
       await fetchPlan()
       this.setState({ isSubmitting: false })
     }


### PR DESCRIPTION
The confirmation endpoint seems to update the status of the plan to `14` automatically. This isn't the status we want when submitting for feedback, so I've added a check to only update confirmations when submitted for final decision.