### PR TITLE
Wait for pasture creation when saving draft

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -224,7 +224,7 @@ export const savePastures = (planId, pastures) => {
         return { ...pasture, oldId: pasture.id }
       } else {
         const { id, ...values } = pasture
-        const { data } = axios.post(
+        const { data } = await axios.post(
           API.CREATE_RUP_PASTURE(planId),
           values,
           getAuthHeaderConfig()


### PR DESCRIPTION
There was a missing `await` when creating new pastures, which caused an error when a new pasture and plant community were added.

Relates to #321 