### PR TITLE
setOpen to false on date click in DayMonthPicker

### DIFF
--- a/src/components/common/form/DayMonthPicker.js
+++ b/src/components/common/form/DayMonthPicker.js
@@ -123,6 +123,7 @@ const DayMonthPicker = connect(
 
                               formik.setFieldValue(monthName, date.month() + 1)
                               formik.setFieldValue(dayName, date.date())
+                              setOpen(false)
                             }}
                             style={{
                               backgroundColor:


### PR DESCRIPTION
This is to address the issue https://github.com/bcgov/range-web/issues/168

When a date is chosen the calendar closes.