### PR TITLE
planStartDate is assigned a value but never used

### DIFF
--- a/src/utils/helper/plan.js
+++ b/src/utils/helper/plan.js
@@ -38,7 +38,6 @@ export const scrollIntoView = elementId => {
 
 // for plans extending past agreement date, extend usage
 export const appendUsage = plan => {
-  let planStartDate = new Date(plan.planStartDate)
   let planEndDate = new Date(plan.planEndDate)
   let agrEndDate = new Date(plan.agreement.agreementEndDate)
 


### PR DESCRIPTION
Fixes `eslint` warning.

<img width="640" alt="Screen Shot 2019-11-24 at 11 54 42 AM" src="https://user-images.githubusercontent.com/15054821/69500583-3cc89500-0eb1-11ea-8270-2d32ebe67e6a.png">
