### PR TITLE
Fix which statuses are editable

### DIFF
--- a/src/components/rangeUsePlanPage/pastures/PastureBox.js
+++ b/src/components/rangeUsePlanPage/pastures/PastureBox.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import PermissionsField from '../../common/PermissionsField'
+import PermissionsField, { IfEditable } from '../../common/PermissionsField'
 import { PASTURES } from '../../../constants/fields'
 import { Input } from 'formik-semantic-ui'
 import { Dropdown, Icon } from 'semantic-ui-react'
@@ -47,29 +47,31 @@ const PastureBox = ({
               Pasture: {pasture.name}
             </div>
 
-            <div>
-              {activeIndex === index && (
-                <Icon
-                  name="edit"
-                  onClick={e => {
-                    setModalOpen(true)
-                    e.stopPropagation()
+            <IfEditable permission={PASTURES.NAME}>
+              <div>
+                {activeIndex === index && (
+                  <Icon
+                    name="edit"
+                    onClick={e => {
+                      setModalOpen(true)
+                      e.stopPropagation()
+                    }}
+                  />
+                )}
+                <Dropdown
+                  className="rup__pasture__actions"
+                  trigger={<i className="ellipsis vertical icon" />}
+                  options={dropdownOptions}
+                  icon={null}
+                  pointing="right"
+                  onClick={e => e.stopPropagation()}
+                  onChange={(e, { value }) => {
+                    if (value === 'copy') onCopy()
                   }}
+                  selectOnBlur={false}
                 />
-              )}
-              <Dropdown
-                className="rup__pasture__actions"
-                trigger={<i className="ellipsis vertical icon" />}
-                options={dropdownOptions}
-                icon={null}
-                pointing="right"
-                onClick={e => e.stopPropagation()}
-                onChange={(e, { value }) => {
-                  if (value === 'copy') onCopy()
-                }}
-                selectOnBlur={false}
-              />
-            </div>
+              </div>
+            </IfEditable>
           </div>
         }
         collapsibleContent={

--- a/src/utils/helper/plan.js
+++ b/src/utils/helper/plan.js
@@ -159,7 +159,7 @@ export const canUserSubmitConfirmation = (status, user, confirmations = []) => {
 }
 
 export const canUserEditThisPlan = (plan = {}, user = {}) => {
-  const { status, creatorId } = plan
+  const { status } = plan
 
   if (isStatusStaffDraft(status) || isStatusSubmittedForReview(status)) {
     return user.roles.includes('myra_range_officer')
@@ -173,15 +173,6 @@ export const canUserEditThisPlan = (plan = {}, user = {}) => {
     isStatusRecommendForSubmission(status)
   ) {
     return user.roles.includes('myra_client')
-  }
-
-  if (isPlanAmendment(plan)) {
-    if (status && creatorId && user.id) {
-      return canAllowRevisionForAH(status) && creatorId === user.id
-    }
-  } else {
-    // initial plan
-    return canAllowRevisionForAH(status)
   }
 
   return false


### PR DESCRIPTION
Removes an extra status check which was causing the plan to be incorrectly editable for certain statuses

Also hides the pasture menus when not editable.

Relates to #326 