### PR TITLE
Refetch plan when signed

### DIFF
--- a/src/components/rangeUsePlanPage/pageForAH/AHSignatureModal.js
+++ b/src/components/rangeUsePlanPage/pageForAH/AHSignatureModal.js
@@ -63,6 +63,7 @@ class AHSignatureModal extends Component {
 
       confirmationUpdated({ confirmation })
       this.setState({ isConfirming: false })
+      if (this.props.onSuccess) this.props.onSuccess()
     }
     const onError = err => {
       this.setState({ isConfirming: false })

--- a/src/components/rangeUsePlanPage/pageForAH/index.js
+++ b/src/components/rangeUsePlanPage/pageForAH/index.js
@@ -265,6 +265,7 @@ class PageForAH extends Component {
           clients={clients}
           updateStatusAndContent={this.updateStatusAndContent}
           fetchPlan={fetchPlan}
+          onSuccess={() => fetchPlan()}
         />
 
         <AmendmentSubmissionModal


### PR DESCRIPTION
Refetches the plan after an agreement holder successfully adds their signature to make sure the correct information is shown.

Relates to #335 