### PR TITLE
Fix grazing schedule entry validation 

### DIFF
--- a/src/utils/validation/grazingSchedule.js
+++ b/src/utils/validation/grazingSchedule.js
@@ -17,7 +17,7 @@ export const handleGrazingScheduleEntryValidation = (e = {}) => {
     e.dateOut &&
     e.pastureId &&
     e.livestockTypeId &&
-    e.livestockCount
+    !isNaN(parseFloat(e.livestockCount))
   ) {
     // valid entry
   } else {


### PR DESCRIPTION
Check if `livestockCount` is a number, rather than just `if (livestockCount)`, which will fail for situations where the value is 0.

Relates to #361 