### PR TITLE
Add versioning support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30831,6 +30831,23 @@
         }
       }
     },
+    "swr": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-0.1.8.tgz",
+      "integrity": "sha512-vQ1QVzxw8AtTn6v4OQV3eVskt5mlKu0/Nsbay2PyxJVynw0oFbPMAVfVgwJ3siPGvywugAwWU5o46Ceh/CNrxA==",
+      "requires": {
+        "fast-deep-equal": "2.0.1",
+        "lodash.throttle": "4.1.1",
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "semantic-ui": "^2.4.2",
     "semantic-ui-calendar-react": "^0.15.3",
     "semantic-ui-react": "^0.88.1",
+    "swr": "^0.1.8",
     "uuid-v4": "^0.1.0",
     "yup": "^0.27.0"
   },

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -259,13 +259,11 @@ export const savePlantCommunities = (planId, pastureId, plantCommunities) => {
           getAuthHeaderConfig()
         )).data.id
       } else {
-        const { data: updatedCommunity } = await axios.put(
+        await axios.put(
           API.UPDATE_RUP_PLANT_COMMUNITY(planId, pastureId, communityId),
           values,
           getAuthHeaderConfig()
         )
-
-        return updatedCommunity
       }
 
       await savePlantCommunityActions(
@@ -305,8 +303,18 @@ const savePlantCommunityActions = (
           values,
           getAuthHeaderConfig()
         )
+      } else {
+        return axios.put(
+          API.UPDATE_RUP_PLANT_COMMUNITY_ACTION(
+            planId,
+            pastureId,
+            communityId,
+            actionId
+          ),
+          values,
+          getAuthHeaderConfig()
+        )
       }
-      return Promise.resolve()
     })
   )
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -365,8 +365,18 @@ const saveMonitoringAreas = (
           values,
           getAuthHeaderConfig()
         )
+      } else {
+        return axios.put(
+          API.UPDATE_RUP_MONITORING_AREA(
+            planId,
+            pastureId,
+            communityId,
+            areaId
+          ),
+          values,
+          getAuthHeaderConfig()
+        )
       }
-      return Promise.resolve()
     })
   )
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -8,6 +8,10 @@ export const getPlan = async planId => {
   return data
 }
 
+export const createVersion = async planId => {
+  await axios.post(API.CREATE_RUP_VERSION(planId), {}, getAuthHeaderConfig())
+}
+
 export const saveGrazingSchedules = (planId, grazingSchedules) => {
   return Promise.all(
     grazingSchedules.map(async schedule => {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -258,6 +258,14 @@ export const savePlantCommunities = (planId, pastureId, plantCommunities) => {
           values,
           getAuthHeaderConfig()
         )).data.id
+      } else {
+        const { data: updatedCommunity } = await axios.put(
+          API.UPDATE_RUP_PLANT_COMMUNITY(planId, pastureId, communityId),
+          values,
+          getAuthHeaderConfig()
+        )
+
+        return updatedCommunity
       }
 
       await savePlantCommunityActions(

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -119,6 +119,14 @@ export const saveAdditionalRequirements = (planId, additionalRequirements) => {
           ...requirement,
           id: data.id
         }
+      } else {
+        await axios.put(
+          API.UPDATE_RUP_ADDITIONAL_REQUIREMENT(planId, requirement.id),
+          requirement,
+          getAuthHeaderConfig()
+        )
+
+        return requirement
       }
     })
   )

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -334,8 +334,18 @@ const saveIndicatorPlants = (
           values,
           getAuthHeaderConfig()
         )
+      } else {
+        return axios.put(
+          API.UPDATE_RUP_INDICATOR_PLANT(
+            planId,
+            pastureId,
+            communityId,
+            plantId
+          ),
+          values,
+          getAuthHeaderConfig()
+        )
       }
-      return Promise.resolve()
     })
   )
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -24,6 +24,7 @@ import Router from './router'
 import UserProvider from '../providers/UserProvider'
 import ReferencesProvider from '../providers/ReferencesProvider'
 import ToastProvider from '../providers/ToastProvider'
+import EditableProvider from '../providers/EditableProvider'
 
 const store = configureStore()
 
@@ -32,11 +33,13 @@ class App extends Component {
     return (
       <Provider store={store}>
         <UserProvider>
-          <ReferencesProvider>
-            <ToastProvider>
-              <Router />
-            </ToastProvider>
-          </ReferencesProvider>
+          <EditableProvider editable={true}>
+            <ReferencesProvider>
+              <ToastProvider>
+                <Router />
+              </ToastProvider>
+            </ReferencesProvider>
+          </EditableProvider>
         </UserProvider>
       </Provider>
     )

--- a/src/components/rangeUsePlanPage/ActionBtns.js
+++ b/src/components/rangeUsePlanPage/ActionBtns.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button } from 'semantic-ui-react'
+import { Button, Icon, Menu, Dropdown } from 'semantic-ui-react'
 import { connect } from 'formik'
 import {
   SAVE_DRAFT,
@@ -12,12 +12,14 @@ import {
 } from '../../constants/strings'
 import { CONFIRMATION_MODAL_ID } from '../../constants/variables'
 import DownloadPDFBtn from './DownloadPDFBtn'
+import UpdateStatusDropdown from './pageForStaff/UpdateStatusDropdown'
 
 const ActionBtns = ({
   canEdit,
   canAmend,
   canConfirm,
   canSubmit,
+  canUpdateStatus,
   isSubmitting,
   isCreatingAmendment,
   onViewPDFClicked,
@@ -26,7 +28,10 @@ const ActionBtns = ({
   openSubmissionModal,
   openAHSignatureModal,
   openConfirmationModal,
-  formik
+  formik,
+  plan,
+  isFetchingPlan,
+  fetchPlan
 }) => {
   const downloadPDFBtn = (
     <DownloadPDFBtn key="downloadPDFBtn" onClick={onViewPDFClicked} />
@@ -42,6 +47,7 @@ const ActionBtns = ({
         formik.submitForm()
       }}
       style={{ marginRight: '0', marginLeft: '10px' }}>
+      <Icon name="save" />
       {SAVE_DRAFT}
     </Button>
   )
@@ -54,17 +60,14 @@ const ActionBtns = ({
       loading={isSubmitting}
       onClick={openSubmissionModal}
       style={{ marginRight: '0', marginLeft: '10px' }}>
+      <Icon name="check" />
       {SUBMIT}
     </Button>
   )
-  const amendBtn = (
-    <Button
+  const amendMenuItem = (
+    <Menu.Item
       key="amendBtn"
-      inverted
-      compact
-      content={AMEND_PLAN}
       loading={isCreatingAmendment}
-      style={{ marginRight: '0', marginLeft: '10px' }}
       onClick={() => {
         openConfirmationModal({
           id: CONFIRMATION_MODAL_ID.AMEND_PLAN,
@@ -73,51 +76,50 @@ const ActionBtns = ({
           onYesBtnClicked: onAmendPlanClicked,
           closeAfterYesBtnClicked: true
         })
-      }}
-    />
+      }}>
+      <Icon name="edit" />
+      {AMEND_PLAN}
+    </Menu.Item>
   )
-  const confirmSubmissionBtn = (
-    <Button
-      key="confirmSubmissionBtn"
-      inverted
-      compact
-      style={{ marginRight: '0', marginLeft: '10px' }}
-      onClick={openAHSignatureModal}>
+  const confirmSubmissionMenuItem = (
+    <Menu.Item key="confirmSubmissionBtn" onClick={openAHSignatureModal}>
       {SIGN_SUBMISSION}
-    </Button>
+    </Menu.Item>
   )
-  const viewVersionsBtn = (
-    <Button
-      key="viewVersionnBtn"
-      type="button"
-      inverted
-      compact
-      style={{ marginRight: '0', marginLeft: '10px' }}
-      onClick={onViewVersionsClicked}>
+  const viewVersionsMenuItem = (
+    <Menu.Item key="viewVersionBtn" onClick={onViewVersionsClicked}>
+      <Icon name="history" />
       {VIEW_VERSIONS}
-    </Button>
+    </Menu.Item>
   )
 
-  if (canSubmit && !canEdit) {
-    return [downloadPDFBtn, submitBtn]
-  }
-  if (canEdit && !canSubmit) {
-    return [downloadPDFBtn, saveDraftBtn]
-  }
-  if (canEdit) {
-    return [downloadPDFBtn, viewVersionsBtn, saveDraftBtn, submitBtn]
-  }
-  if (canAmend) {
-    return [downloadPDFBtn, viewVersionsBtn, amendBtn]
-  }
-  if (canConfirm) {
-    return [downloadPDFBtn, viewVersionsBtn, confirmSubmissionBtn]
-  }
-  if (canSubmit) {
-    return [downloadPDFBtn, viewVersionsBtn, submitBtn]
-  }
-
-  return [downloadPDFBtn, viewVersionsBtn]
+  return (
+    <>
+      {canEdit && saveDraftBtn}
+      {canSubmit && submitBtn}
+      <Dropdown
+        trigger={<Icon name="ellipsis vertical" inverted />}
+        closeOnBlur
+        icon={null}
+        pointing="top right"
+        style={{ marginLeft: 10 }}
+        value={null}>
+        <Dropdown.Menu>
+          {downloadPDFBtn}
+          {viewVersionsMenuItem}
+          {canConfirm && confirmSubmissionMenuItem}
+          {canAmend && amendMenuItem}
+          {canUpdateStatus && (
+            <UpdateStatusDropdown
+              plan={plan}
+              fetchPlan={fetchPlan}
+              isFetchingPlan={isFetchingPlan}
+            />
+          )}
+        </Dropdown.Menu>
+      </Dropdown>
+    </>
+  )
 }
 
 export default connect(ActionBtns)

--- a/src/components/rangeUsePlanPage/ActionBtns.js
+++ b/src/components/rangeUsePlanPage/ActionBtns.js
@@ -7,7 +7,8 @@ import {
   AMEND_PLAN,
   SIGN_SUBMISSION,
   AMEND_PLAN_CONFIRM_HEADER,
-  AMEND_PLAN_CONFIRM_CONTENT
+  AMEND_PLAN_CONFIRM_CONTENT,
+  VIEW_VERSIONS
 } from '../../constants/strings'
 import { CONFIRMATION_MODAL_ID } from '../../constants/variables'
 import DownloadPDFBtn from './DownloadPDFBtn'
@@ -21,6 +22,7 @@ const ActionBtns = ({
   isCreatingAmendment,
   onViewPDFClicked,
   onAmendPlanClicked,
+  onViewVersionsClicked,
   openSubmissionModal,
   openAHSignatureModal,
   openConfirmationModal,
@@ -84,6 +86,17 @@ const ActionBtns = ({
       {SIGN_SUBMISSION}
     </Button>
   )
+  const viewVersionsBtn = (
+    <Button
+      key="viewVersionnBtn"
+      type="button"
+      inverted
+      compact
+      style={{ marginRight: '0', marginLeft: '10px' }}
+      onClick={onViewVersionsClicked}>
+      {VIEW_VERSIONS}
+    </Button>
+  )
 
   if (canSubmit && !canEdit) {
     return [downloadPDFBtn, submitBtn]
@@ -92,19 +105,19 @@ const ActionBtns = ({
     return [downloadPDFBtn, saveDraftBtn]
   }
   if (canEdit) {
-    return [downloadPDFBtn, saveDraftBtn, submitBtn]
+    return [downloadPDFBtn, viewVersionsBtn, saveDraftBtn, submitBtn]
   }
   if (canAmend) {
-    return [downloadPDFBtn, amendBtn]
+    return [downloadPDFBtn, viewVersionsBtn, amendBtn]
   }
   if (canConfirm) {
-    return [downloadPDFBtn, confirmSubmissionBtn]
+    return [downloadPDFBtn, viewVersionsBtn, confirmSubmissionBtn]
   }
   if (canSubmit) {
-    return [downloadPDFBtn, submitBtn]
+    return [downloadPDFBtn, viewVersionsBtn, submitBtn]
   }
 
-  return downloadPDFBtn
+  return [downloadPDFBtn, viewVersionsBtn]
 }
 
 export default connect(ActionBtns)

--- a/src/components/rangeUsePlanPage/DownloadPDFBtn.js
+++ b/src/components/rangeUsePlanPage/DownloadPDFBtn.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react'
-import { Button, Icon } from 'semantic-ui-react'
+import { Icon, Menu } from 'semantic-ui-react'
 import PropTypes from 'prop-types'
 import { DOWNLOAD_PDF } from '../../constants/strings'
 
@@ -14,27 +14,10 @@ const defaultProps = {
 
 const DownloadPDFBtn = ({ onClick, disabled }) => (
   <Fragment>
-    <Button
-      className="rup__download-pdf-btn--short"
-      compact
-      inverted
-      disabled={disabled}
-      onClick={onClick}
-      type="button"
-      icon="file pdf outline"
-      style={{ marginRight: '0' }}
-    />
-    <Button
-      className="rup__download-pdf-btn--long"
-      compact
-      inverted
-      disabled={disabled}
-      onClick={onClick}
-      type="button"
-      style={{ marginRight: '0' }}>
+    <Menu.Item disabled={disabled} onClick={onClick}>
       <Icon name="file pdf outline" />
       {DOWNLOAD_PDF}
-    </Button>
+    </Menu.Item>
   </Fragment>
 )
 

--- a/src/components/rangeUsePlanPage/PlanForm.js
+++ b/src/components/rangeUsePlanPage/PlanForm.js
@@ -10,14 +10,9 @@ import InvasivePlantChecklist from './invasivePlantChecklist'
 import ManagementConsiderations from './managementConsiderations'
 import MinisterIssues from './ministerIssues'
 import AdditionalRequirements from './additionalRequirements'
-import { canUserEditThisPlan } from '../../utils'
-import { useUser } from '../../providers/UserProvider'
 import EditableProvider from '../../providers/EditableProvider'
 
-const PlanForm = ({ plan }) => {
-  const user = useUser()
-  const isEditable = canUserEditThisPlan(plan, user)
-
+const PlanForm = ({ plan, isEditable = true }) => {
   return (
     <EditableProvider editable={isEditable}>
       <Element name={ELEMENT_ID.BASIC_INFORMATION}>

--- a/src/components/rangeUsePlanPage/additionalRequirements/AdditionalRequirementRow.js
+++ b/src/components/rangeUsePlanPage/additionalRequirements/AdditionalRequirementRow.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { isUUID } from 'uuid-v4'
 import PermissionsField from '../../common/PermissionsField'
 import { ADDITIONAL_REQUIREMENTS } from '../../../constants/fields'
 import { useReferences } from '../../../providers/ReferencesProvider'

--- a/src/components/rangeUsePlanPage/additionalRequirements/AdditionalRequirementRow.js
+++ b/src/components/rangeUsePlanPage/additionalRequirements/AdditionalRequirementRow.js
@@ -19,8 +19,6 @@ const AdditionalRequirementRow = ({ additionalRequirement, namespace }) => {
 
   const { detail, url, categoryId } = additionalRequirement
 
-  const isEditable = isUUID(additionalRequirement.id)
-
   return (
     <div className="rup__a-requirement__row">
       <PermissionsField
@@ -36,7 +34,6 @@ const AdditionalRequirementRow = ({ additionalRequirement, namespace }) => {
         }
         label="Category"
         fast
-        editable={!isEditable}
       />
       <div>
         <PermissionsField
@@ -47,7 +44,6 @@ const AdditionalRequirementRow = ({ additionalRequirement, namespace }) => {
           inputProps={{ placeholder: 'Details' }}
           label="Details"
           fast
-          editable={!isEditable}
         />
 
         <PermissionsField
@@ -57,7 +53,6 @@ const AdditionalRequirementRow = ({ additionalRequirement, namespace }) => {
           label="URL"
           inputProps={{ placeholder: 'URL', fluid: true }}
           fast
-          editable={!isEditable}
         />
       </div>
     </div>

--- a/src/components/rangeUsePlanPage/index.js
+++ b/src/components/rangeUsePlanPage/index.js
@@ -50,7 +50,8 @@ import {
   saveMinisterIssues,
   getPlan,
   savePastures,
-  savePlantCommunities
+  savePlantCommunities,
+  createVersion
 } from '../../api'
 import PDFView from './pdf/PDFView'
 
@@ -132,6 +133,8 @@ const Base = ({
       await saveManagementConsiderations(plan.id, managementConsiderations)
       await saveMinisterIssues(plan.id, ministerIssues, newPastures)
       await saveAdditionalRequirements(plan.id, additionalRequirements)
+
+      await createVersion(plan.id)
 
       formik.setSubmitting(false)
       successToast('Successfully saved draft')

--- a/src/components/rangeUsePlanPage/pageForAH/SubmissionModal.js
+++ b/src/components/rangeUsePlanPage/pageForAH/SubmissionModal.js
@@ -13,6 +13,7 @@ import TabsForSingleAH from './tabs/TabsForSingleAH'
 import { findConfirmationWithClientId } from '../../../utils'
 import TabsForMultipleAH from './tabs/TabsForMultipleAH'
 import { updateRUPConfirmation } from '../../../actionCreators/planActionCreator'
+import { createVersion } from '../../../api'
 
 class SubmissionModal extends Component {
   static propTypes = {
@@ -80,7 +81,6 @@ class SubmissionModal extends Component {
       )
       const confirmed = true
       const isMinorAmendment = false
-
       if (status.id === 14) {
         await updateRUPConfirmation(
           plan,
@@ -89,6 +89,8 @@ class SubmissionModal extends Component {
           isMinorAmendment
         )
       }
+
+      await createVersion(plan.id)
       await fetchPlan()
       this.setState({ isSubmitting: false })
     }

--- a/src/components/rangeUsePlanPage/pageForAH/index.js
+++ b/src/components/rangeUsePlanPage/pageForAH/index.js
@@ -25,7 +25,7 @@ import {
   savePastures
 } from '../../../api'
 import RUPSchema from '../schema'
-import { getAuthHeaderConfig } from '../../../utils'
+import { getAuthHeaderConfig, canUserEditThisPlan } from '../../../utils'
 
 // Agreement Holder page
 class PageForAH extends Component {
@@ -314,7 +314,12 @@ class PageForAH extends Component {
             planStatusHistoryMap={planStatusHistoryMap}
           />
 
-          {plan && <PlanForm plan={plan} />}
+          {plan && (
+            <PlanForm
+              plan={plan}
+              isEditable={canUserEditThisPlan(plan, user)}
+            />
+          )}
         </ContentsContainer>
       </section>
     )

--- a/src/components/rangeUsePlanPage/pageForAH/index.js
+++ b/src/components/rangeUsePlanPage/pageForAH/index.js
@@ -166,6 +166,11 @@ class PageForAH extends Component {
     this.props.history.push(`/range-use-plan/${planId}/export-pdf`)
   }
 
+  onViewVersionsClicked = () => {
+    const { id: planId } = this.props.plan || {}
+    this.props.history.push(`/range-use-plan/${planId}/versions`)
+  }
+
   openSubmissionModal = () => {
     const { plan } = this.props
     const error = this.validateRup(plan)
@@ -204,6 +209,7 @@ class PageForAH extends Component {
         isSubmitting={isSubmitting}
         isCreatingAmendment={isCreatingAmendment}
         onViewPDFClicked={this.onViewPDFClicked}
+        onViewVersionsClicked={this.onViewVersionsClicked}
         onSaveDraftClick={this.onSaveDraftClick}
         onAmendPlanClicked={this.onAmendPlanClicked}
         openSubmissionModal={this.openSubmissionModal}

--- a/src/components/rangeUsePlanPage/pageForStaff/UpdateStatusDropdown.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/UpdateStatusDropdown.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { Dropdown, Button, Icon } from 'semantic-ui-react'
+import { Menu, Divider } from 'semantic-ui-react'
 import {
   isStatusStands,
   isStatusCreated,
@@ -213,7 +213,7 @@ class UpdateStatusDropdown extends Component {
 
   render() {
     const { modal, updateStatusModalOpen } = this.state
-    const { plan, isUpdatingStatus, fetchPlan, isFetchingPlan } = this.props
+    const { plan, isFetchingPlan } = this.props
     const status = plan && plan.status
 
     const statusDropdownOptions = this.getStatusDropdownOptions(
@@ -224,30 +224,19 @@ class UpdateStatusDropdown extends Component {
 
     return (
       <Fragment>
-        <Dropdown
-          className="rup__update-status-dropdown"
-          options={statusDropdownOptions}
-          disabled={
-            isFetchingPlan || statusDropdownOptions[0].key === 'noOption'
-          }
-          pointing="top"
-          icon={null}
-          onClick={fetchPlan}
-          trigger={
-            <Button
-              inverted
-              loading={isUpdatingStatus}
-              compact
-              type="button"
-              style={{ margin: '0' }}>
-              {strings.PLAN_ACTIONS}
-              <Icon
-                name="caret down"
-                style={{ marginRight: '-5px', marginLeft: '5px' }}
-              />
-            </Button>
-          }
-        />
+        <>
+          <Divider />
+          <Menu.Header>{strings.PLAN_ACTIONS}</Menu.Header>
+          {statusDropdownOptions.map(o => (
+            <Menu.Item
+              key={o.key}
+              value={o.text}
+              onClick={o.onClick}
+              disabled={o.key === 'noOption'}>
+              {o.text}
+            </Menu.Item>
+          ))}
+        </>
         <UpdateStatusModal
           open={updateStatusModalOpen}
           onClose={this.closeUpdateStatusModalOpen}

--- a/src/components/rangeUsePlanPage/pageForStaff/UpdateStatusModal.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/UpdateStatusModal.js
@@ -83,6 +83,8 @@ class UpdateStatusModal extends Component {
         size="tiny"
         open={open}
         onClose={onClose}
+        onFocus={e => e.stopPropagation()}
+        onClick={e => e.stopPropagation()}
         closeIcon={<Icon name="close" color="black" />}>
         <Modal.Header as="h2" content={header} />
         <Modal.Content>

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -7,7 +7,6 @@ import * as utils from '../../../utils'
 import BackBtn from '../BackBtn'
 import * as API from '../../../constants/api'
 import ContentsContainer from '../ContentsContainer'
-import UpdateStatusDropdown from './UpdateStatusDropdown'
 import StickyHeader from '../StickyHeader'
 import Notifications from '../notifications'
 import { defaultProps, propTypes } from './props'
@@ -155,6 +154,10 @@ class PageForStaff extends Component {
         onViewVersionsClicked={this.onViewVersionsClicked}
         onSaveDraftClick={this.onSaveDraftClick}
         openSubmissionModal={this.openPlanSubmissionModal}
+        plan={this.props.plan}
+        isFetchingPlan={this.props.isFetchingPlan}
+        fetchPlan={this.props.fetchPlan}
+        canUpdateStatus
       />
     )
   }
@@ -167,7 +170,6 @@ class PageForStaff extends Component {
       plan,
       planStatusHistoryMap,
       fetchPlan,
-      isFetchingPlan,
       updateRUPStatus
     } = this.props
     const { isUpdateZoneModalOpen, isPlanSubmissionModalOpen } = this.state
@@ -221,11 +223,6 @@ class PageForStaff extends Component {
               </div>
               <div className="rup__actions__btns">
                 {this.renderActionBtns(canEdit, canSubmit)}
-                <UpdateStatusDropdown
-                  plan={plan}
-                  fetchPlan={fetchPlan}
-                  isFetchingPlan={isFetchingPlan}
-                />
               </div>
             </div>
           </div>

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -15,7 +15,7 @@ import ActionBtns from '../ActionBtns'
 import UpdateStatusModal from './UpdateStatusModal'
 import PlanForm from '../PlanForm'
 import RUPSchema from '../schema'
-import { getAuthHeaderConfig } from '../../../utils'
+import { getAuthHeaderConfig, canUserEditThisPlan } from '../../../utils'
 import {
   savePastures,
   savePlantCommunities,
@@ -240,7 +240,12 @@ class PageForStaff extends Component {
             planTypeDescription={planTypeDescription}
           />
 
-          {plan && <PlanForm plan={plan} />}
+          {plan && (
+            <PlanForm
+              plan={plan}
+              isEditable={canUserEditThisPlan(plan, user)}
+            />
+          )}
         </ContentsContainer>
       </section>
     )

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -130,6 +130,11 @@ class PageForStaff extends Component {
     this.props.history.push(`/range-use-plan/${planId}/export-pdf`)
   }
 
+  onViewVersionsClicked = () => {
+    const { id: planId } = this.props.plan || {}
+    this.props.history.push(`/range-use-plan/${planId}/versions`)
+  }
+
   openUpdateZoneModal = () => this.setState({ isUpdateZoneModalOpen: true })
   closeUpdateZoneModal = () => this.setState({ isUpdateZoneModalOpen: false })
   openPlanSubmissionModal = () =>
@@ -147,6 +152,7 @@ class PageForStaff extends Component {
         isSubmitting={isSubmitting}
         isSavingAsDraft={isSavingAsDraft}
         onViewPDFClicked={this.onViewPDFClicked}
+        onViewVersionsClicked={this.onViewVersionsClicked}
         onSaveDraftClick={this.onSaveDraftClick}
         openSubmissionModal={this.openPlanSubmissionModal}
       />

--- a/src/components/rangeUsePlanPage/plantCommunities/index.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/index.js
@@ -30,12 +30,14 @@ const PlantCommunities = ({ plantCommunities = [], namespace }) => {
                   purposeOfAction: 'none',
                   monitoringAreas: [],
                   aspect: '',
-                  elevation: 0,
+                  elevationId: null,
                   url: '',
                   approved: false,
                   notes: '',
-                  rangeReadinessDate: '',
-                  rangeReadinessNote: '',
+                  rangeReadinessDay: null,
+                  rangeReadinessMonth: null,
+                  rangeReadinessNote: null,
+                  shrubUse: '',
                   id: uuid()
                 })
               }}

--- a/src/components/rangeUsePlanPage/schema.js
+++ b/src/components/rangeUsePlanPage/schema.js
@@ -48,7 +48,9 @@ const RUPSchema = Yup.object().shape({
             .required('Required field'),
           url: Yup.string().transform(handleNull()),
           purposeOfAction: Yup.string().required('Required field'),
-          shrubUse: Yup.string().transform(handleNull()),
+          shrubUse: Yup.number()
+            .transform((v, originalValue) => (originalValue === '' ? null : v))
+            .nullable(),
           rangeReadinessMonth: Yup.number()
             .transform((v, originalValue) => (originalValue === '' ? null : v))
             .nullable(),

--- a/src/components/rangeUsePlanPage/versionsList/NoVersions.js
+++ b/src/components/rangeUsePlanPage/versionsList/NoVersions.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Segment, Header, Icon, Container } from 'semantic-ui-react'
+import { Link } from 'react-router-dom'
+import { RANGE_USE_PLAN } from '../../../constants/routes'
+import { PrimaryButton } from '../../common'
+
+const NoVersions = ({ planId }) => {
+  return (
+    <Container>
+      <Segment placeholder>
+        <Header icon>
+          <Icon name="question circle" />
+          This plan does not have any past versions
+        </Header>
+        <PrimaryButton
+          as={Link}
+          to={`${RANGE_USE_PLAN}/${planId}`}
+          icon
+          labelPosition="left">
+          <Icon name="arrow left" />
+          Go back to RUP
+        </PrimaryButton>
+      </Segment>
+    </Container>
+  )
+}
+
+export default NoVersions

--- a/src/components/rangeUsePlanPage/versionsList/Version.js
+++ b/src/components/rangeUsePlanPage/versionsList/Version.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import useSWR from 'swr'
+import * as API from '../../../constants/api'
+import { axios, getAuthHeaderConfig } from '../../../utils'
+import PlanForm from '../PlanForm'
+import { Form } from 'formik-semantic-ui'
+import { Header, Divider, Placeholder } from 'semantic-ui-react'
+import moment from 'moment'
+
+const Version = ({ planId, version, updatedAt }) => {
+  const endpoint = API.GET_RUP_VERSION(planId, version)
+
+  const { data, loading, error } = useSWR(endpoint, key =>
+    axios.get(key, getAuthHeaderConfig()).then(res => res.data)
+  )
+  if (error) return <span>Error: {error.message}</span>
+  if (loading || !data)
+    return (
+      <Placeholder>
+        {Array.from({ length: 10 }).map((_, i) => (
+          <Placeholder.Paragraph key={i}>
+            <Placeholder.Line />
+            <Placeholder.Line />
+            <Placeholder.Line />
+            <Placeholder.Line />
+            <Placeholder.Line />
+          </Placeholder.Paragraph>
+        ))}
+      </Placeholder>
+    )
+  return (
+    <>
+      <Header>
+        <Header.Content>
+          {data.agreement.id}, Version {version}
+        </Header.Content>
+        <Header.Subheader>
+          {moment(updatedAt).format('MMMM Do, YYYY, h:mm a ')}
+        </Header.Subheader>
+      </Header>
+      <Divider />
+      <Form
+        initialValues={data}
+        render={({ values }) => <PlanForm plan={values} />}
+      />
+    </>
+  )
+}
+
+export default Version

--- a/src/components/rangeUsePlanPage/versionsList/Version.js
+++ b/src/components/rangeUsePlanPage/versionsList/Version.js
@@ -4,17 +4,16 @@ import * as API from '../../../constants/api'
 import { axios, getAuthHeaderConfig } from '../../../utils'
 import PlanForm from '../PlanForm'
 import { Form } from 'formik-semantic-ui'
-import { Header, Divider, Placeholder } from 'semantic-ui-react'
-import moment from 'moment'
+import { Placeholder } from 'semantic-ui-react'
 
-const Version = ({ planId, version, updatedAt }) => {
+const Version = ({ planId, version }) => {
   const endpoint = API.GET_RUP_VERSION(planId, version)
 
-  const { data, loading, error } = useSWR(endpoint, key =>
+  const { data, isValidating, error } = useSWR(endpoint, key =>
     axios.get(key, getAuthHeaderConfig()).then(res => res.data)
   )
   if (error) return <span>Error: {error.message}</span>
-  if (loading || !data)
+  if (isValidating || !data)
     return (
       <Placeholder>
         {Array.from({ length: 10 }).map((_, i) => (
@@ -30,18 +29,9 @@ const Version = ({ planId, version, updatedAt }) => {
     )
   return (
     <>
-      <Header>
-        <Header.Content>
-          {data.agreement.id}, Version {version}
-        </Header.Content>
-        <Header.Subheader>
-          {moment(updatedAt).format('MMMM Do, YYYY, h:mm a ')}
-        </Header.Subheader>
-      </Header>
-      <Divider />
       <Form
         initialValues={data}
-        render={({ values }) => <PlanForm plan={values} />}
+        render={({ values }) => <PlanForm plan={values} isEditable={false} />}
       />
     </>
   )

--- a/src/components/rangeUsePlanPage/versionsList/VersionToolbar.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionToolbar.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Menu } from 'semantic-ui-react'
+import { getAuthHeaderConfig, axios } from '../../../utils'
+import * as API from '../../../constants/api'
+import useSWR from 'swr'
+import moment from 'moment'
+import { Status } from '../../common'
+import { useUser } from '../../../providers/UserProvider'
+
+const VersionToolbar = ({ planId, version }) => {
+  const user = useUser()
+
+  const { data } = useSWR(API.GET_RUP_VERSION(planId, version), key =>
+    axios.get(key, getAuthHeaderConfig()).then(res => res.data)
+  )
+
+  if (data) {
+    return (
+      <>
+        <Menu.Item header>{data.agreementId}</Menu.Item>
+        <Menu.Item>
+          {moment(data.updatedAt).format('MMMM Do, YYYY, h:mm a ')}
+        </Menu.Item>
+        <Menu.Item>
+          <Status status={data.status} user={user} />
+        </Menu.Item>
+      </>
+    )
+  }
+
+  return null
+}
+
+export default VersionToolbar

--- a/src/components/rangeUsePlanPage/versionsList/VersionsList.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsList.js
@@ -16,6 +16,7 @@ import { axios, getAuthHeaderConfig } from '../../../utils'
 import moment from 'moment'
 import Version from './Version'
 import EditableProvider from '../../../providers/EditableProvider'
+import NoVersions from './NoVersions'
 
 const sortVersions = (a, b) => {
   if (b.version === -1) return 1
@@ -35,57 +36,62 @@ const VersionsList = ({ match }) => {
 
   const contextRef = useRef()
 
+  const { versions = [] } = data || {}
+  const formattedVersions = versions
+    .sort(sortVersions)
+    .filter(v => v.version !== -1)
+
   if (error) return <div>Error: {JSON.stringify(error.message)}</div>
   return (
     <EditableProvider editable={false}>
-      <Grid columns="equal" padded>
-        <Grid.Column width="12">
-          <Ref innerRef={contextRef}>
-            <Segment padded>
-              {selectedVersion ? (
-                <Version {...selectedVersion} planId={planId} />
-              ) : (
-                <Container>Please select a version on the right</Container>
-              )}
-              <Rail position="right">
-                <Sticky context={contextRef}>
-                  <Segment loading={loading || !data}>
-                    <Header attached="top">Versions</Header>
-                    <List selection animated>
-                      {data &&
-                        data.versions
-                          .sort(sortVersions)
-                          .filter(v => v.version !== -1)
-                          .map(version => (
-                            <List.Item
-                              active={
-                                selectedVersion &&
-                                version.version === selectedVersion.version
-                              }
-                              key={version.planId}
-                              onClick={() => setSelectedVersion(version)}>
-                              <Label>
-                                {version.version === -1
-                                  ? 'Current'
-                                  : `v${version.version}`}
-                              </Label>
-                              <List.Content
-                                floated="right"
-                                verticalAlign="middle">
-                                {moment(version.updatedAt).format(
-                                  'MMMM Do, YYYY, h:mm a '
-                                )}
-                              </List.Content>
-                            </List.Item>
-                          ))}
-                    </List>
-                  </Segment>
-                </Sticky>
-              </Rail>
-            </Segment>
-          </Ref>
-        </Grid.Column>
-      </Grid>
+      {formattedVersions.length === 0 ? (
+        <NoVersions planId={planId} />
+      ) : (
+        <Grid columns="equal" padded>
+          <Grid.Column width="12">
+            <Ref innerRef={contextRef}>
+              <Segment padded placeholder={!selectedVersion}>
+                {selectedVersion ? (
+                  <Version {...selectedVersion} planId={planId} />
+                ) : (
+                  <Container>Please select a version on the right</Container>
+                )}
+                <Rail position="right">
+                  <Sticky context={contextRef}>
+                    <Segment loading={loading || !data}>
+                      <Header attached="top">Versions</Header>
+                      <List selection animated>
+                        {formattedVersions.map(version => (
+                          <List.Item
+                            active={
+                              selectedVersion &&
+                              version.version === selectedVersion.version
+                            }
+                            key={version.planId}
+                            onClick={() => setSelectedVersion(version)}>
+                            <Label>
+                              {version.version === -1
+                                ? 'Current'
+                                : `v${version.version}`}
+                            </Label>
+                            <List.Content
+                              floated="right"
+                              verticalAlign="middle">
+                              {moment(version.updatedAt).format(
+                                'MMMM Do, YYYY, h:mm a '
+                              )}
+                            </List.Content>
+                          </List.Item>
+                        ))}
+                      </List>
+                    </Segment>
+                  </Sticky>
+                </Rail>
+              </Segment>
+            </Ref>
+          </Grid.Column>
+        </Grid>
+      )}
     </EditableProvider>
   )
 }

--- a/src/components/rangeUsePlanPage/versionsList/VersionsList.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsList.js
@@ -1,22 +1,11 @@
 import React, { useState, useRef } from 'react'
 import useSWR from 'swr'
-import {
-  Grid,
-  Segment,
-  List,
-  Sticky,
-  Ref,
-  Rail,
-  Header,
-  Label,
-  Container
-} from 'semantic-ui-react'
+import { Grid, Segment, Sticky, Ref, Container } from 'semantic-ui-react'
 import * as API from '../../../constants/api'
 import { axios, getAuthHeaderConfig } from '../../../utils'
-import moment from 'moment'
 import Version from './Version'
-import EditableProvider from '../../../providers/EditableProvider'
 import NoVersions from './NoVersions'
+import VersionsToolbar from './VersionsToolbar'
 
 const sortVersions = (a, b) => {
   if (b.version === -1) return 1
@@ -30,7 +19,7 @@ const VersionsList = ({ match }) => {
   const [selectedVersion, setSelectedVersion] = useState(null)
   const endpoint = API.GET_RUP_VERSIONS(planId)
 
-  const { data, error, loading } = useSWR(endpoint, key =>
+  const { data, error, isValidating } = useSWR(endpoint, key =>
     axios.get(key, getAuthHeaderConfig()).then(res => res.data)
   )
 
@@ -43,56 +32,39 @@ const VersionsList = ({ match }) => {
 
   if (error) return <div>Error: {JSON.stringify(error.message)}</div>
   return (
-    <EditableProvider editable={false}>
-      {formattedVersions.length === 0 ? (
+    <>
+      {!isValidating && formattedVersions.length === 0 ? (
         <NoVersions planId={planId} />
       ) : (
-        <Grid columns="equal" padded>
-          <Grid.Column width="12">
-            <Ref innerRef={contextRef}>
-              <Segment padded placeholder={!selectedVersion}>
-                {selectedVersion ? (
-                  <Version {...selectedVersion} planId={planId} />
-                ) : (
-                  <Container>Please select a version on the right</Container>
-                )}
-                <Rail position="right">
-                  <Sticky context={contextRef}>
-                    <Segment loading={loading || !data}>
-                      <Header attached="top">Versions</Header>
-                      <List selection animated>
-                        {formattedVersions.map(version => (
-                          <List.Item
-                            active={
-                              selectedVersion &&
-                              version.version === selectedVersion.version
-                            }
-                            key={version.planId}
-                            onClick={() => setSelectedVersion(version)}>
-                            <Label>
-                              {version.version === -1
-                                ? 'Current'
-                                : `v${version.version}`}
-                            </Label>
-                            <List.Content
-                              floated="right"
-                              verticalAlign="middle">
-                              {moment(version.updatedAt).format(
-                                'MMMM Do, YYYY, h:mm a '
-                              )}
-                            </List.Content>
-                          </List.Item>
-                        ))}
-                      </List>
-                    </Segment>
-                  </Sticky>
-                </Rail>
-              </Segment>
-            </Ref>
-          </Grid.Column>
+        <Grid columns="equal" padded centered>
+          <Grid.Row>
+            <Grid.Column width="10">
+              <Sticky context={contextRef}>
+                <VersionsToolbar
+                  planId={planId}
+                  versions={formattedVersions}
+                  selectedVersion={selectedVersion}
+                  onSelectVersion={(e, { value }) => setSelectedVersion(value)}
+                />
+              </Sticky>
+
+              <Ref innerRef={contextRef}>
+                <Segment
+                  padded
+                  placeholder={!selectedVersion}
+                  attached="bottom">
+                  {selectedVersion ? (
+                    <Version {...selectedVersion} planId={planId} />
+                  ) : (
+                    <Container>Please select a version</Container>
+                  )}
+                </Segment>
+              </Ref>
+            </Grid.Column>
+          </Grid.Row>
         </Grid>
       )}
-    </EditableProvider>
+    </>
   )
 }
 

--- a/src/components/rangeUsePlanPage/versionsList/VersionsList.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsList.js
@@ -1,0 +1,93 @@
+import React, { useState, useRef } from 'react'
+import useSWR from 'swr'
+import {
+  Grid,
+  Segment,
+  List,
+  Sticky,
+  Ref,
+  Rail,
+  Header,
+  Label,
+  Container
+} from 'semantic-ui-react'
+import * as API from '../../../constants/api'
+import { axios, getAuthHeaderConfig } from '../../../utils'
+import moment from 'moment'
+import Version from './Version'
+import EditableProvider from '../../../providers/EditableProvider'
+
+const sortVersions = (a, b) => {
+  if (b.version === -1) return 1
+  if (b.version > a.version) return 1
+  if (b.version < a.version) return -1
+  return 0
+}
+
+const VersionsList = ({ match }) => {
+  const { planId } = match.params
+  const [selectedVersion, setSelectedVersion] = useState(null)
+  const endpoint = API.GET_RUP_VERSIONS(planId)
+
+  const { data, error, loading } = useSWR(endpoint, key =>
+    axios.get(key, getAuthHeaderConfig()).then(res => res.data)
+  )
+
+  const contextRef = useRef()
+
+  if (error) return <div>Error: {JSON.stringify(error.message)}</div>
+  return (
+    <EditableProvider editable={false}>
+      <Grid columns="equal" padded>
+        <Grid.Column width="12">
+          <Ref innerRef={contextRef}>
+            <Segment padded>
+              {selectedVersion ? (
+                <Version {...selectedVersion} planId={planId} />
+              ) : (
+                <Container>Please select a version on the right</Container>
+              )}
+              <Rail position="right">
+                <Sticky context={contextRef}>
+                  <Segment loading={loading || !data}>
+                    <Header attached="top">Versions</Header>
+                    <List selection animated>
+                      {data &&
+                        data.versions
+                          .sort(sortVersions)
+                          .filter(v => v.version !== -1)
+                          .map(version => (
+                            <List.Item
+                              active={
+                                selectedVersion &&
+                                version.version === selectedVersion.version
+                              }
+                              key={version.planId}
+                              onClick={() => setSelectedVersion(version)}>
+                              <Label>
+                                {version.version === -1
+                                  ? 'Current'
+                                  : `v${version.version}`}
+                              </Label>
+                              <List.Content
+                                floated="right"
+                                verticalAlign="middle">
+                                {moment(version.updatedAt).format(
+                                  'MMMM Do, YYYY, h:mm a '
+                                )}
+                              </List.Content>
+                            </List.Item>
+                          ))}
+                    </List>
+                  </Segment>
+                </Sticky>
+              </Rail>
+            </Segment>
+          </Ref>
+        </Grid.Column>
+      </Grid>
+    </EditableProvider>
+  )
+}
+
+export default VersionsList

--- a/src/components/rangeUsePlanPage/versionsList/VersionsList.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsList.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from 'react'
 import useSWR from 'swr'
-import { Grid, Segment, Sticky, Ref, Container } from 'semantic-ui-react'
+import { Segment, Sticky, Ref, Container } from 'semantic-ui-react'
 import * as API from '../../../constants/api'
 import { axios, getAuthHeaderConfig } from '../../../utils'
 import Version from './Version'
@@ -36,33 +36,26 @@ const VersionsList = ({ match }) => {
       {!isValidating && formattedVersions.length === 0 ? (
         <NoVersions planId={planId} />
       ) : (
-        <Grid columns="equal" padded centered>
-          <Grid.Row>
-            <Grid.Column width="10">
-              <Sticky context={contextRef}>
-                <VersionsToolbar
-                  planId={planId}
-                  versions={formattedVersions}
-                  selectedVersion={selectedVersion}
-                  onSelectVersion={(e, { value }) => setSelectedVersion(value)}
-                />
-              </Sticky>
+        <Container>
+          <Sticky context={contextRef}>
+            <VersionsToolbar
+              planId={planId}
+              versions={formattedVersions}
+              selectedVersion={selectedVersion}
+              onSelectVersion={(e, { value }) => setSelectedVersion(value)}
+            />
+          </Sticky>
 
-              <Ref innerRef={contextRef}>
-                <Segment
-                  padded
-                  placeholder={!selectedVersion}
-                  attached="bottom">
-                  {selectedVersion ? (
-                    <Version {...selectedVersion} planId={planId} />
-                  ) : (
-                    <Container>Please select a version</Container>
-                  )}
-                </Segment>
-              </Ref>
-            </Grid.Column>
-          </Grid.Row>
-        </Grid>
+          <Ref innerRef={contextRef}>
+            <Segment padded placeholder={!selectedVersion} attached="bottom">
+              {selectedVersion ? (
+                <Version {...selectedVersion} planId={planId} />
+              ) : (
+                <Container>Please select a version</Container>
+              )}
+            </Segment>
+          </Ref>
+        </Container>
       )}
     </>
   )

--- a/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { Menu, Icon, Dropdown } from 'semantic-ui-react'
+import { Link } from 'react-router-dom'
+import { RANGE_USE_PLAN } from '../../../constants/routes'
+import { PrimaryButton } from '../../common'
+import VersionToolbar from './VersionToolbar'
+
+const VersionsToolbar = ({
+  versions,
+  selectedVersion,
+  onSelectVersion,
+  planId
+}) => {
+  const versionOptions = versions.map(v => ({
+    key: v.version,
+    value: v,
+    text: `v${v.version}`
+  }))
+
+  return (
+    <>
+      <Menu attached="top">
+        <Menu.Item>
+          <PrimaryButton as={Link} to={`${RANGE_USE_PLAN}/${planId}`}>
+            <Icon name="arrow left" />
+            Back to RUP
+          </PrimaryButton>
+        </Menu.Item>
+
+        <Dropdown
+          item
+          options={versionOptions}
+          value={selectedVersion}
+          placeholder="Select a version"
+          onChange={onSelectVersion}
+        />
+
+        {selectedVersion && (
+          <VersionToolbar planId={planId} version={selectedVersion.version} />
+        )}
+      </Menu>
+    </>
+  )
+}
+
+export default VersionsToolbar

--- a/src/components/router/index.js
+++ b/src/components/router/index.js
@@ -60,22 +60,6 @@ const Router = () => {
         />
         {/* Admin Routes End */}
 
-        <ProtectedRoute
-          path={Routes.HOME}
-          component={SelectRangeUsePlan}
-          user={user}
-        />
-        <ProtectedRoute
-          path={Routes.RANGE_USE_PLAN_WITH_PARAM}
-          component={RangeUsePlan}
-          user={user}
-        />
-        <ProtectedRoute
-          path={Routes.EXPORT_PDF_WITH_PARAM}
-          component={PDFView}
-          user={user}
-        />
-
         <PublicRoute path={Routes.LOGIN} component={LoginPage} user={user} />
 
         <ProtectedRoute

--- a/src/components/router/index.js
+++ b/src/components/router/index.js
@@ -26,6 +26,7 @@ import ProtectedRoute from './ProtectedRoute'
 import { useUser } from '../../providers/UserProvider'
 import * as Routes from '../../constants/routes'
 import { LoadableComponent } from './LoadableComponent'
+import VersionsList from '../rangeUsePlanPage/versionsList/VersionsList'
 
 const SelectRangeUsePlan = LoadableComponent(() =>
   import('../selectRangeUsePlanPage')
@@ -62,6 +63,29 @@ const Router = () => {
         <ProtectedRoute
           path={Routes.HOME}
           component={SelectRangeUsePlan}
+          user={user}
+        />
+        <ProtectedRoute
+          path={Routes.RANGE_USE_PLAN_WITH_PARAM}
+          component={RangeUsePlan}
+          user={user}
+        />
+        <ProtectedRoute
+          path={Routes.EXPORT_PDF_WITH_PARAM}
+          component={PDFView}
+          user={user}
+        />
+
+        <PublicRoute path={Routes.LOGIN} component={LoginPage} user={user} />
+
+        <ProtectedRoute
+          path={Routes.HOME}
+          component={SelectRangeUsePlan}
+          user={user}
+        />
+        <ProtectedRoute
+          path={Routes.VIEW_PLAN_VERSIONS}
+          component={VersionsList}
           user={user}
         />
         <ProtectedRoute

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -141,6 +141,8 @@ export const DELETE_RUP_MINISTER_ISSUE_ACTION = (planId, issueId, actionId) =>
 
 export const CREATE_RUP_PLANT_COMMUNITY = (planId, pastureId) =>
   `/v1/plan/${planId}/pasture/${pastureId}/plant-community`
+export const UPDATE_RUP_PLANT_COMMUNITY = (planId, pastureId, plantId) =>
+  `/v1/plan/${planId}/pasture/${pastureId}/plant-community/${plantId}`
 export const CREATE_RUP_PLANT_COMMUNITY_ACTION = (
   planId,
   pastureId,

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -149,6 +149,13 @@ export const CREATE_RUP_PLANT_COMMUNITY_ACTION = (
   communityId
 ) =>
   `/v1/plan/${planId}/pasture/${pastureId}/plant-community/${communityId}/action`
+export const UPDATE_RUP_PLANT_COMMUNITY_ACTION = (
+  planId,
+  pastureId,
+  communityId,
+  actionId
+) =>
+  `/v1/plan/${planId}/pasture/${pastureId}/plant-community/${communityId}/action/${actionId}`
 
 export const CREATE_RUP_INDICATOR_PLANT = (planId, pastureId, communityId) =>
   `/v1/plan/${planId}/pasture/${pastureId}/plant-community/${communityId}/indicator-plant`

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -106,6 +106,11 @@ export const UPDATE_RUP = planId => `/v1/plan/${planId}`
 export const UPDATE_CONFIRMATION = (planId, confirmationId) =>
   `/v1/plan/${planId}/confirmation/${confirmationId}`
 
+export const CREATE_RUP_VERSION = planId => `/v1/plan/${planId}/version`
+export const GET_RUP_VERSIONS = planId => `/v1/plan/${planId}/version`
+export const GET_RUP_VERSION = (planId, version) =>
+  `/v1/plan/${planId}/version/${version}`
+
 export const CREATE_RUP_STATUS_RECORD = planId =>
   `/v1/plan/${planId}/status-record`
 export const CREATE_RUP_PASTURE = planId => `/v1/plan/${planId}/pasture`

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -168,6 +168,13 @@ export const UPDATE_RUP_INDICATOR_PLANT = (
   `/v1/plan/${planId}/pasture/${pastureId}/plant-community/${communityId}/indicator-plant/${plantId}`
 export const CREATE_RUP_MONITERING_AREA = (planId, pastureId, communityId) =>
   `/v1/plan/${planId}/pasture/${pastureId}/plant-community/${communityId}/monitoring-area`
+export const UPDATE_RUP_MONITORING_AREA = (
+  planId,
+  pastureId,
+  communityId,
+  areaId
+) =>
+  `/v1/plan/${planId}/pasture/${pastureId}/plant-community/${communityId}/monitoring-area/${areaId}`
 export const CREATE_RUP_INVASIVE_PLANT_CHECKLIST = planId =>
   `/v1/plan/${planId}/invasive-plant-checklist`
 export const UPDATE_RUP_INVASIVE_PLANT_CHECKLIST = (planId, checklistId) =>

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -164,3 +164,5 @@ export const DELETE_RUP_MANAGEMENT_CONSIDERATION = (planId, considerationId) =>
   `/v1/plan/${planId}/management-consideration/${considerationId}`
 export const CREATE_RUP_ADDITIONAL_REQUIREMENT = planId =>
   `/v1/plan/${planId}/additional-requirement`
+export const UPDATE_RUP_ADDITIONAL_REQUIREMENT = (planId, requirementId) =>
+  `/v1/plan/${planId}/additional-requirement/${requirementId}`

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -159,6 +159,13 @@ export const UPDATE_RUP_PLANT_COMMUNITY_ACTION = (
 
 export const CREATE_RUP_INDICATOR_PLANT = (planId, pastureId, communityId) =>
   `/v1/plan/${planId}/pasture/${pastureId}/plant-community/${communityId}/indicator-plant`
+export const UPDATE_RUP_INDICATOR_PLANT = (
+  planId,
+  pastureId,
+  communityId,
+  plantId
+) =>
+  `/v1/plan/${planId}/pasture/${pastureId}/plant-community/${communityId}/indicator-plant/${plantId}`
 export const CREATE_RUP_MONITERING_AREA = (planId, pastureId, communityId) =>
   `/v1/plan/${planId}/pasture/${pastureId}/plant-community/${communityId}/monitoring-area`
 export const CREATE_RUP_INVASIVE_PLANT_CHECKLIST = planId =>

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -5,6 +5,7 @@ export const RETURN_PAGE = '/return-page'
 export const RANGE_USE_PLAN = '/range-use-plan'
 export const EXPORT_PDF = '/export-pdf'
 export const EXPORT_PDF_WITH_PARAM = '/range-use-plan/:planId/export-pdf/'
+export const VIEW_PLAN_VERSIONS = '/range-use-plan/:planId/versions'
 export const RANGE_USE_PLAN_WITH_PARAM = '/range-use-plan/:planId'
 
 export const MANAGE_ZONE = '/manage-zone'

--- a/src/constants/strings.js
+++ b/src/constants/strings.js
@@ -35,6 +35,7 @@ export const AMEND_PLAN = 'Amend Plan'
 export const SIGN_SUBMISSION = 'Sign Submission'
 export const VIEW = 'View'
 export const AWAITING_CONFIRMATION = 'Awaiting Confirmation'
+export const VIEW_VERSIONS = 'View Versions'
 
 // RUP tabs
 export const BASIC_INFORMATION = 'Basic Information'

--- a/src/utils/hooks/plan.js
+++ b/src/utils/hooks/plan.js
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react'
+import * as API from '../../constants/api'
+import {
+  getLocalPlans,
+  savePlanToLocalStorage,
+  getPlan,
+  getPlans
+} from '../../api'
+import { axios } from '..'
+import useSWR from 'swr'
+import { getAuthHeaderConfig } from '../authentication'
+
+export const usePlans = agreementId => {
+  const [plans, setPlans] = useState([])
+  const { data: agreement, isValidating, revalidate, error } = useSWR(
+    agreementId && API.GET_AGREEMENT(agreementId),
+    key => axios.get(key, getAuthHeaderConfig()).then(res => res.data)
+  )
+
+  const { remotePlans = [] } = agreement || {}
+
+  const savePlans = async plans => {
+    await Promise.all(plans.map(async p => savePlanToLocalStorage(p, true)))
+  }
+
+  const localPlans = getPlans().filter(p => p.agreementId === agreementId)
+
+  useEffect(() => {
+    savePlans(remotePlans)
+  }, [remotePlans])
+
+  useEffect(() => {
+    // setPlans(getPlans().filter(p => p.agreementId === agreementId))
+    console.log('updating')
+  }, [agreementId, localPlans])
+
+  return { plans, isValidating, revalidate, error }
+}


### PR DESCRIPTION
Changes:
* Adds a new route for viewing of past versions of a plan
* Creates new version of a plan whenever it is saved (we'll probably want to change this, to only change on status update)
* Adds edit functionality to a few more components, thanks to new endpoints introduced in https://github.com/bcgov/range-api/pull/77

I'm not entirely sold on the UI for the version page. Suggestions would be appreciated. I've also moved some of the action buttons at the top into a dropdown, since we were accumulating them and they started to break the layout.