### PR TITLE
Adjust when submit button appears based on user role and plan status

### DIFF
--- a/src/components/rangeUsePlanPage/ActionBtns.js
+++ b/src/components/rangeUsePlanPage/ActionBtns.js
@@ -85,6 +85,9 @@ const ActionBtns = ({
     </Button>
   )
 
+  if (canSubmit && !canEdit) {
+    return [downloadPDFBtn, submitBtn]
+  }
   if (canEdit && !canSubmit) {
     return [downloadPDFBtn, saveDraftBtn]
   }

--- a/src/components/rangeUsePlanPage/pageForAH/index.js
+++ b/src/components/rangeUsePlanPage/pageForAH/index.js
@@ -239,7 +239,7 @@ class PageForAH extends Component {
       user,
       confirmations
     )
-    const canSubmit = utils.isStatusRecommendForSubmission(status)
+    const canSubmit = utils.canUserSubmitPlan(plan, user)
     const {
       header: bannerHeader,
       content: bannerContent

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -169,7 +169,7 @@ class PageForStaff extends Component {
     const { agreementId, status, rangeName } = plan
 
     const canEdit = utils.canUserEditThisPlan(plan, user)
-    const canSubmit = utils.isStatusRecommendForSubmission(status)
+    const canSubmit = utils.canUserSubmitPlan(plan, user)
 
     const amendmentTypes = references[REFERENCE_KEY.AMENDMENT_TYPE]
     const planTypeDescription = utils.getPlanTypeDescription(

--- a/src/utils/helper/plan.js
+++ b/src/utils/helper/plan.js
@@ -142,6 +142,18 @@ export const isStatusIndicatingStaffFeedbackNeeded = status =>
 export const isNoteRequired = statusCode =>
   REQUIRE_NOTES_PLAN_STATUSES.includes(statusCode)
 
+export const canUserSubmitPlan = (plan = {}, user = {}) => {
+  const { status } = plan
+  if (!status || !status.code || !user || !user.roles) return false
+
+  if (user.roles.includes('myra_range_officer')) {
+    return status.code === PLAN_STATUS.STAFF_DRAFT
+  }
+  if (user.roles.includes('myra_client')) {
+    return canUserEditThisPlan(plan, user)
+  }
+}
+
 export const canUserSubmitConfirmation = (status, user, confirmations = []) => {
   if (isStatusAwaitingConfirmation(status) && user) {
     let isConfirmed = false


### PR DESCRIPTION
> * AH needs "Submit" for all statuses they can edit (see #326 for list).
> * staff need "plan actions" and no submit for all statuses they can edit EXCEPT 6 in which they need the submit button instead
> * for statuses no one can edit there should be neither submit nor plan actions for anyone.

Relates to #374 and #375