### PR TITLE
Persist plant community action deletes

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -452,3 +452,20 @@ export const deleteMonitoringArea = async (
     getAuthHeaderConfig()
   )
 }
+
+export const deletePlantCommunityAction = async (
+  planId,
+  pastureId,
+  communityId,
+  actionId
+) => {
+  await axios.delete(
+    API.DELETE_RUP_PLANT_COMMUNITY_ACTION(
+      planId,
+      pastureId,
+      communityId,
+      actionId
+    ),
+    getAuthHeaderConfig()
+  )
+}

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityActionsBox.js
@@ -6,8 +6,15 @@ import { IfEditable } from '../../common/PermissionsField'
 import { PLANT_COMMUNITY } from '../../../constants/fields'
 import { Button, Confirm } from 'semantic-ui-react'
 import PlantCommunityAction from './PlantCommunityAction'
+import { deletePlantCommunityAction } from '../../../api'
 
-const PlantCommunityActionsBox = ({ actions, namespace }) => {
+const PlantCommunityActionsBox = ({
+  actions,
+  planId,
+  pastureId,
+  communityId,
+  namespace
+}) => {
   const [toRemove, setToRemove] = useState(null)
 
   return (
@@ -30,7 +37,18 @@ const PlantCommunityActionsBox = ({ actions, namespace }) => {
             onCancel={() => {
               setToRemove(null)
             }}
-            onConfirm={() => {
+            onConfirm={async () => {
+              const action = actions[toRemove]
+
+              if (!uuid.isUUID(action.id)) {
+                await deletePlantCommunityAction(
+                  planId,
+                  pastureId,
+                  communityId,
+                  action.id
+                )
+              }
+
               remove(toRemove)
               setToRemove(null)
             }}

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityBox.js
@@ -281,6 +281,9 @@ const PlantCommunityBox = ({
               </div>
               <PlantCommunityActionsBox
                 actions={plantCommunityActions}
+                planId={planId}
+                pastureId={pastureId}
+                communityId={plantCommunity.id}
                 namespace={namespace}
               />
             </>

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -165,6 +165,13 @@ export const UPDATE_RUP_PLANT_COMMUNITY_ACTION = (
   actionId
 ) =>
   `/v1/plan/${planId}/pasture/${pastureId}/plant-community/${communityId}/action/${actionId}`
+export const DELETE_RUP_PLANT_COMMUNITY_ACTION = (
+  planId,
+  pastureId,
+  communityId,
+  actionId
+) =>
+  `/v1/plan/${planId}/pasture/${pastureId}/plant-community/${communityId}/action/${actionId}`
 
 export const CREATE_RUP_INDICATOR_PLANT = (planId, pastureId, communityId) =>
   `/v1/plan/${planId}/pasture/${pastureId}/plant-community/${communityId}/indicator-plant`


### PR DESCRIPTION
Previously, deletions were only client-side and didn't reflect any change in the database.