### PR TITLE
Fix ManagementConsiderations header to display in every row and to match AdditionalRequirements

### DIFF
--- a/src/components/rangeUsePlanPage/managementConsiderations/ManagementConsiderationRow.js
+++ b/src/components/rangeUsePlanPage/managementConsiderations/ManagementConsiderationRow.js
@@ -5,7 +5,7 @@ import { MANAGEMENT_CONSIDERATIONS } from '../../../constants/fields'
 import { useReferences } from '../../../providers/ReferencesProvider'
 import { REFERENCE_KEY } from '../../../constants/variables'
 import { TextArea } from 'formik-semantic-ui'
-import { Dropdown, Icon, Form } from 'semantic-ui-react'
+import { Dropdown, Icon } from 'semantic-ui-react'
 import { Dropdown as FormikDropdown } from 'formik-semantic-ui'
 
 const ManagementConsiderationRow = ({
@@ -32,59 +32,48 @@ const ManagementConsiderationRow = ({
 
   return (
     <div className="rup__m-consideration__row">
+      <PermissionsField
+        permission={MANAGEMENT_CONSIDERATIONS.TYPE}
+        name={`${namespace}.considerationTypeId`}
+        component={FormikDropdown}
+        options={considerTypeOptions}
+        label={'Considerations'}
+        displayValue={
+          considerTypes.find(type => type.id === considerationTypeId)
+            ? considerTypes.find(type => type.id === considerationTypeId).name
+            : ''
+        }
+        inputProps={{
+          fluid: true
+        }}
+      />
       <div>
         <PermissionsField
-          permission={MANAGEMENT_CONSIDERATIONS.TYPE}
-          name={`${namespace}.considerationTypeId`}
-          component={FormikDropdown}
-          options={considerTypeOptions}
-          displayValue={
-            considerTypes.find(type => type.id === considerationTypeId)
-              ? considerTypes.find(type => type.id === considerationTypeId).name
-              : ''
-          }
-          inputProps={{
-            fluid: true
-          }}
+          permission={MANAGEMENT_CONSIDERATIONS.DESCRIPTION}
+          name={`${namespace}.detail`}
+          component={TextArea}
+          displayValue={detail}
+          label={'Details'}
+        />
+        <PermissionsField
+          permission={MANAGEMENT_CONSIDERATIONS.DESCRIPTION}
+          name={`${namespace}.url`}
+          displayValue={url}
+          label={'URL'}
         />
       </div>
-      <div>
-        <Form.Group widths="equal">
-          <div style={{ width: '100%', marginLeft: '5px' }}>
-            <PermissionsField
-              permission={MANAGEMENT_CONSIDERATIONS.DESCRIPTION}
-              name={`${namespace}.detail`}
-              component={TextArea}
-              displayValue={detail}
-            />
-            <PermissionsField
-              permission={MANAGEMENT_CONSIDERATIONS.DESCRIPTION}
-              name={`${namespace}.url`}
-              displayValue={url}
-              label="URL"
-              fieldProps={{
-                style: {
-                  marginTop: '5px'
-                }
-              }}
-            />
-          </div>
 
-          <IfEditable permission={MANAGEMENT_CONSIDERATIONS.NAME}>
-            <div className="rup__m-consideration__ellipsis">
-              <Dropdown
-                trigger={
-                  <Icon name="ellipsis vertical" style={{ margin: '0' }} />
-                }
-                options={ellipsisOptions}
-                icon={null}
-                pointing="right"
-                style={{ marginLeft: '5px', marginTop: '10px' }}
-              />
-            </div>
-          </IfEditable>
-        </Form.Group>
-      </div>
+      <IfEditable permission={MANAGEMENT_CONSIDERATIONS.NAME}>
+        <div className="rup__m-consideration__ellipsis">
+          <Dropdown
+            trigger={<Icon name="ellipsis vertical" style={{ margin: '0' }} />}
+            options={ellipsisOptions}
+            icon={null}
+            pointing="right"
+            style={{ marginLeft: '5px', marginTop: '10px' }}
+          />
+        </div>
+      </IfEditable>
     </div>
   )
 }

--- a/src/components/rangeUsePlanPage/managementConsiderations/index.js
+++ b/src/components/rangeUsePlanPage/managementConsiderations/index.js
@@ -38,11 +38,6 @@ const ManagementConsiderations = ({ planId, managementConsiderations }) => {
             </div>
 
             <div className="rup__m-considerations__box">
-              <div className="rup__m-consideration__header">
-                <div>Considerations</div>
-                <div>Details</div>
-              </div>
-
               {managementConsiderations.length === 0 ? (
                 <div className="rup__m-considerations__no-content">
                   No management considerations provided

--- a/src/styles/RupConsiderationAndRequirement.scss
+++ b/src/styles/RupConsiderationAndRequirement.scss
@@ -74,4 +74,9 @@
       }
     }
   }
+  &__m-consideration__row {
+    > div > .rup__m-consideration__header {
+      padding-bottom: 12px;
+    }
+  }
 }


### PR DESCRIPTION
The `Considerations` and `Details` header were fixed to the top of the box and weren't displaying above anything but the first box. They should appear in every box above their inputs and with the same styling as the `URL` header (and the headers in the `Additional Requirements` boxes). 

### Old

![Screen Shot 2019-12-20 at 12 51 38 PM](https://user-images.githubusercontent.com/15054821/71291497-b4aaa380-2327-11ea-8998-0789a866995f.png)

![Screen Shot 2019-12-20 at 12 50 58 PM](https://user-images.githubusercontent.com/15054821/71291601-fc312f80-2327-11ea-8634-89473cc90100.png)

![Screen Shot 2019-12-20 at 12 58 33 PM](https://user-images.githubusercontent.com/15054821/71291981-942f1900-2328-11ea-8b4c-5f58478d7016.png)

### New

<img width="667" alt="Screen Shot 2019-12-20 at 12 52 21 PM" src="https://user-images.githubusercontent.com/15054821/71291496-b4120d00-2327-11ea-87f1-833327c660fc.png">

![Screen Shot 2019-12-20 at 12 54 26 PM](https://user-images.githubusercontent.com/15054821/71291607-ffc4b680-2327-11ea-9a39-8da3043b4c73.png)

![Screen Shot 2019-12-20 at 12 58 07 PM](https://user-images.githubusercontent.com/15054821/71292090-9a24fa00-2328-11ea-8a4f-f684dec45c74.png)
