### PR TITLE
Change validation functions to use pasture array

### DIFF
--- a/src/components/rangeUsePlanPage/pageForAH/index.js
+++ b/src/components/rangeUsePlanPage/pageForAH/index.js
@@ -141,12 +141,13 @@ class PageForAH extends Component {
   }
 
   validateRup = plan => {
-    const { references, agreement, pasturesMap } = this.props
+    const { references, agreement } = this.props
+    const { pastures } = plan
     const usage = agreement && agreement.usage
     const livestockTypes = references[REFERENCE_KEY.LIVESTOCK_TYPE]
     const errors = utils.handleRupValidation(
       plan,
-      pasturesMap,
+      pastures,
       livestockTypes,
       usage
     )

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -104,12 +104,13 @@ class PageForStaff extends Component {
   }
 
   validateRup = plan => {
-    const { references, agreement, pasturesMap } = this.props
+    const { references, agreement } = this.props
+    const { pastures } = plan
     const usage = agreement && agreement.usage
     const livestockTypes = references[REFERENCE_KEY.LIVESTOCK_TYPE]
     const errors = utils.handleRupValidation(
       plan,
-      pasturesMap,
+      pastures,
       livestockTypes,
       usage
     )

--- a/src/utils/validation/grazingSchedule.js
+++ b/src/utils/validation/grazingSchedule.js
@@ -40,7 +40,7 @@ export const handleGrazingScheduleEntryValidation = (e = {}) => {
  */
 export const handleGrazingScheduleValidation = (
   schedule = {},
-  pasturesMap = {},
+  pastures = [],
   livestockTypes = [],
   usage = []
 ) => {
@@ -50,7 +50,7 @@ export const handleGrazingScheduleValidation = (
   const authorizedAUMs = yearUsage && yearUsage.authorizedAum
   const crownTotalAUMs = calcCrownTotalAUMs(
     grazingScheduleEntries,
-    pasturesMap,
+    pastures,
     livestockTypes
   )
 

--- a/src/utils/validation/plan.js
+++ b/src/utils/validation/plan.js
@@ -12,7 +12,7 @@ import { handleGrazingScheduleValidation } from './grazingSchedule'
  */
 export const handleRupValidation = (
   plan = {},
-  pasturesMap = {},
+  pastures = [],
   livestockTypes = [],
   usage = []
 ) => {
@@ -24,7 +24,7 @@ export const handleRupValidation = (
       ...errors,
       ...handleGrazingScheduleValidation(
         schedule,
-        pasturesMap,
+        pastures,
         livestockTypes,
         usage
       )


### PR DESCRIPTION
Some validation functions were still expecting a pastures map (leftover from redux). They've been changed to take the pastures array directly.

Relates to #449