### PR TITLE
Fix stubble height delete

### DIFF
--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/StubbleHeightBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/StubbleHeightBox.js
@@ -19,6 +19,7 @@ const StubbleHeightBox = ({ plantCommunity, planId, pastureId, namespace }) => {
         planId={planId}
         pastureId={pastureId}
         criteria={PLANT_CRITERIA.STUBBLE_HEIGHT}
+        communityId={plantCommunity.id}
       />
     </div>
   )


### PR DESCRIPTION
`communityId` wasn't being passed to the `IndicatorPlantsForm` component for stubble height.

Relates to #457