### PR TITLE
Set confirmation to true for multi AH plans on submit

### DIFF
--- a/src/components/rangeUsePlanPage/pageForAH/SubmissionModal.js
+++ b/src/components/rangeUsePlanPage/pageForAH/SubmissionModal.js
@@ -81,7 +81,7 @@ class SubmissionModal extends Component {
       )
       const confirmed = true
       const isMinorAmendment = false
-      if (status.id === 14) {
+      if (status.id === 14 || status.id === 18) {
         await updateRUPConfirmation(
           plan,
           currUserConfirmation.id,


### PR DESCRIPTION
Updates the confirmation to true when submitted for the user that triggered the submission.

(Potentially) relates to #335