### PR TITLE
Verify minister approval before allowing submission

### DIFF
--- a/src/components/common/Loading.js
+++ b/src/components/common/Loading.js
@@ -18,17 +18,24 @@ const defaultProps = {
   size: 'large'
 }
 
-const Loading = ({ size, active, inverted, message, onlySpinner }) => {
+const Loading = ({
+  size,
+  active,
+  inverted,
+  message,
+  onlySpinner,
+  containerProps
+}) => {
   if (onlySpinner) {
     return (
-      <div className="loading-spinner__container">
+      <div className="loading-spinner__container" {...containerProps}>
         <Loader active={active} size={size} content={message} />
       </div>
     )
   }
 
   return (
-    <Dimmer active={active} inverted={inverted}>
+    <Dimmer active={active} inverted={inverted} {...containerProps}>
       <Loader size={size} content={message} />
     </Dimmer>
   )

--- a/src/components/rangeUsePlanPage/ActionBtns.js
+++ b/src/components/rangeUsePlanPage/ActionBtns.js
@@ -32,7 +32,8 @@ const ActionBtns = ({
   formik,
   plan,
   isFetchingPlan,
-  fetchPlan
+  fetchPlan,
+  beforeUpdateStatus
 }) => {
   const isOnline = useNetworkStatus()
 
@@ -125,6 +126,7 @@ const ActionBtns = ({
               plan={plan}
               fetchPlan={fetchPlan}
               isFetchingPlan={isFetchingPlan}
+              beforeUpdateStatus={beforeUpdateStatus}
             />
           )}
         </Dropdown.Menu>

--- a/src/components/rangeUsePlanPage/pageForStaff/UpdateStatusDropdown.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/UpdateStatusDropdown.js
@@ -47,7 +47,9 @@ class UpdateStatusDropdown extends Component {
   }
 
   openConfirmModalForUpdatingPlanStatus = modal => {
-    this.openUpdateStatusModalOpen(modal)
+    if (this.props.beforeUpdateStatus(modal.statusCode)) {
+      this.openUpdateStatusModalOpen(modal)
+    }
   }
 
   openCompletedConfirmModal = () => {

--- a/src/components/rangeUsePlanPage/pageForStaff/UpdateStatusDropdown.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/UpdateStatusDropdown.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { Menu, Divider } from 'semantic-ui-react'
+import { Menu, Divider, Loader, Portal } from 'semantic-ui-react'
 import {
   isStatusStands,
   isStatusCreated,
@@ -20,6 +20,7 @@ import {
 import { updateRUPStatus } from '../../../actionCreators'
 import * as strings from '../../../constants/strings'
 import UpdateStatusModal from './UpdateStatusModal'
+import { Loading } from '../../common'
 
 class UpdateStatusDropdown extends Component {
   static propTypes = {
@@ -34,7 +35,8 @@ class UpdateStatusDropdown extends Component {
 
   state = {
     updateStatusModalOpen: false,
-    modal: null
+    modal: null,
+    loading: false
   }
 
   closeUpdateStatusModalOpen = () =>
@@ -46,10 +48,19 @@ class UpdateStatusDropdown extends Component {
     })
   }
 
-  openConfirmModalForUpdatingPlanStatus = modal => {
-    if (this.props.beforeUpdateStatus(modal.statusCode)) {
-      this.openUpdateStatusModalOpen(modal)
+  openConfirmModalForUpdatingPlanStatus = async modal => {
+    this.setState({ loading: true })
+
+    try {
+      const canUpdate = await this.props.beforeUpdateStatus(modal.statusCode)
+      if (canUpdate) {
+        this.openUpdateStatusModalOpen(modal)
+      }
+    } catch (e) {
+      console.error(e)
     }
+
+    this.setState({ loading: false })
   }
 
   openCompletedConfirmModal = () => {
@@ -245,6 +256,12 @@ class UpdateStatusDropdown extends Component {
           {...this.props}
           {...modal}
         />
+        <Portal open={this.state.loading}>
+          <Loading
+            active={this.state.loading}
+            containerProps={{ page: true }}
+          />
+        </Portal>
       </Fragment>
     )
   }

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -169,6 +169,7 @@ class PageForStaff extends Component {
         canUpdateStatus
         beforeUpdateStatus={async () => {
           await savePlan(this.props.plan)
+          await this.props.fetchPlan()
 
           const error = this.validateRup(this.props.plan)
 

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -22,7 +22,8 @@ import {
   saveInvasivePlantChecklist,
   saveManagementConsiderations,
   saveMinisterIssues,
-  saveAdditionalRequirements
+  saveAdditionalRequirements,
+  savePlan
 } from '../../../api'
 import NetworkStatus from '../../common/NetworkStatus'
 
@@ -166,6 +167,18 @@ class PageForStaff extends Component {
         isFetchingPlan={this.props.isFetchingPlan}
         fetchPlan={this.props.fetchPlan}
         canUpdateStatus
+        beforeUpdateStatus={async () => {
+          await savePlan(this.props.plan)
+
+          const error = this.validateRup(this.props.plan)
+
+          if (error) {
+            this.props.toastErrorMessage(error)
+            return false
+          }
+
+          return true
+        }}
       />
     )
   }

--- a/src/constants/strings.js
+++ b/src/constants/strings.js
@@ -143,6 +143,8 @@ export const EMPTY_GRAZING_SCHEDULE_ENTRIES =
 export const EMPTY_PASTURES = 'Plan must have at least one pasture.'
 export const INVALID_GRAZING_SCHEDULE_ENTRY =
   'Schedule has one or more invalid entries.'
+export const UNAPPROVED_PLANT_COMMUNITIES =
+  'There are one or more plant communities that have not been approved by the minister'
 export const TOTAL_AUMS_EXCEEDS = 'Total AUMs exceeds authorized AUMs.'
 export const USER_NOT_ACTIVE =
   'This account is not active yet. Please contact the administrator (MyRangeBC@gov.bc.ca).'

--- a/src/utils/validation/plan.js
+++ b/src/utils/validation/plan.js
@@ -1,5 +1,6 @@
 import { handleGrazingScheduleValidation } from './grazingSchedule'
 import { handlePastureValidation } from './pasture'
+import { handlePlantCommunityValidation } from './plantCommunity'
 
 /**
  * Validate a range use plan
@@ -34,6 +35,15 @@ export const handleRupValidation = (
   })
 
   errors = [...errors, ...handlePastureValidation(pastures)]
+  errors = [
+    ...errors,
+    ...handlePlantCommunityValidation(
+      pastures.reduce(
+        (communities, pasture) => [...communities, ...pasture.plantCommunities],
+        []
+      )
+    )
+  ]
 
   return errors
 }

--- a/src/utils/validation/plantCommunity.js
+++ b/src/utils/validation/plantCommunity.js
@@ -1,0 +1,16 @@
+import { ELEMENT_ID } from '../../constants/variables'
+import { UNAPPROVED_PLANT_COMMUNITIES } from '../../constants/strings'
+
+export const handlePlantCommunityValidation = plantCommunities => {
+  if (plantCommunities.find(pc => !pc.approved)) {
+    return [
+      {
+        error: true,
+        message: UNAPPROVED_PLANT_COMMUNITIES,
+        elementId: ELEMENT_ID.PASTURES
+      }
+    ]
+  }
+
+  return []
+}


### PR DESCRIPTION
Requires that all plant community "verified by minister" toggles are set to true before staff is allowed to submit a plan to agreement holders.

Relates to #378