### PR TITLE
Add grazing schedule entries sorting

### DIFF
--- a/.storybook/mocks/plan.js
+++ b/.storybook/mocks/plan.js
@@ -81,6 +81,24 @@ export default {
           monitoringAreas: []
         }
       ]
+    },
+    {
+      id: 113,
+      name: 'A different pasture',
+      allowableAum: null,
+      graceDays: null,
+      pldPercent: null,
+      notes: null,
+      planId: 45
+    },
+    {
+      id: 114,
+      name: 'My second pasture',
+      allowableAum: null,
+      graceDays: null,
+      pldPercent: null,
+      notes: null,
+      planId: 45
     }
   ],
   grazingSchedules: [
@@ -96,10 +114,29 @@ export default {
           livestockCount: 1,
           dateIn: '2018-01-16T08:00:00.000Z',
           dateOut: '2018-01-19T08:00:00.000Z',
-          pastureId: 41,
+          pastureId: 1120,
           livestockTypeId: 5,
-          grazingScheduleId: 101,
-          livestockType: { id: 5, name: 'Sheep', auFactor: 0.2, active: true }
+          grazingScheduleId: 101
+        },
+        {
+          id: 111,
+          graceDays: 2,
+          livestockCount: 5,
+          dateIn: '2018-01-11T08:00:00.000Z',
+          dateOut: '2018-03-20T08:00:00.000Z',
+          pastureId: 112,
+          livestockTypeId: 2,
+          grazingScheduleId: 101
+        },
+        {
+          id: 112,
+          graceDays: 5,
+          livestockCount: 2,
+          dateIn: '2018-05-04T08:00:00.000Z',
+          dateOut: '2018-08-04T08:00:00.000Z',
+          pastureId: 114,
+          livestockTypeId: 2,
+          grazingScheduleId: 101
         }
       ]
     },

--- a/src/components/common/SortableTableHeaderCell.js
+++ b/src/components/common/SortableTableHeaderCell.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import { TableHeaderCell } from 'semantic-ui-react'
+
+const SortableTableHeaderCell = ({
+  column,
+  children,
+  currentSortBy,
+  currentSortOrder,
+  onClick,
+  noSort = false
+}) =>
+  noSort ? (
+    <TableHeaderCell className="no-sort-tableheader">
+      {children}
+    </TableHeaderCell>
+  ) : (
+    <TableHeaderCell
+      sorted={currentSortBy === column ? currentSortOrder : null}
+      onClick={() => onClick(column)}>
+      {children}
+    </TableHeaderCell>
+  )
+
+export default SortableTableHeaderCell

--- a/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleEntryRow.js
+++ b/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleEntryRow.js
@@ -18,15 +18,19 @@ const GrazingScheduleEntryRow = ({
   namespace,
   onDelete,
   onCopy,
-  schedule
+  schedule,
+  onChange
 }) => {
   const {
     pastureId,
-    livestockTypeId,
     livestockCount,
     dateIn,
     dateOut,
-    graceDays
+    graceDays,
+    days,
+    pasture,
+    pldAUMs,
+    crownAUMs
   } = entry || {}
 
   const references = useReferences()
@@ -40,21 +44,6 @@ const GrazingScheduleEntryRow = ({
       text: name
     }
   })
-
-  const days = utils.calcDateDiff(dateOut, dateIn, false)
-  const pasture = formik.values.pastures.find(p => p.id === pastureId)
-
-  const pldPercent = pasture && pasture.pldPercent
-  const livestockType = livestockTypes.find(lt => lt.id === livestockTypeId)
-  const auFactor = livestockType && livestockType.auFactor
-
-  const totalAUMs = utils.calcTotalAUMs(livestockCount, days, auFactor)
-  const pldAUMs = utils.roundTo1Decimal(
-    utils.calcPldAUMs(totalAUMs, pldPercent)
-  )
-  const crownAUMs = utils.roundTo1Decimal(
-    utils.calcCrownAUMs(totalAUMs, pldAUMs)
-  )
 
   const entryOptions = [
     { key: 'copy', text: 'Duplicate', onClick: onCopy },
@@ -86,6 +75,7 @@ const GrazingScheduleEntryRow = ({
               `${namespace}.graceDays`,
               pasture.graceDays || 0
             )
+            onChange()
           }}
         />
       </Table.Cell>
@@ -95,14 +85,11 @@ const GrazingScheduleEntryRow = ({
           name={`${namespace}.livestockTypeId`}
           options={livestockTypeOptions}
           component={FormikDropdown}
-          displayValue={
-            livestockTypeOptions.find(o => o.value === livestockTypeId)
-              ? livestockTypeOptions.find(o => o.value === livestockTypeId).text
-              : ''
-          }
+          displayValue={entry.livestockType && entry.livestockType.name}
           inputProps={{
             search: true,
-            'aria-label': 'livestock type'
+            'aria-label': 'livestock type',
+            onChange
           }}
           fast
         />
@@ -113,7 +100,8 @@ const GrazingScheduleEntryRow = ({
           name={`${namespace}.livestockCount`}
           displayValue={livestockCount}
           inputProps={{
-            'aria-label': 'livestock count'
+            'aria-label': 'livestock count',
+            onChange
           }}
           fast
         />
@@ -130,6 +118,7 @@ const GrazingScheduleEntryRow = ({
           minDate={initialDate}
           maxDate={maxDate}
           aria-label="date in"
+          onChange
         />
       </Table.Cell>
       <Table.Cell collapsing>
@@ -144,6 +133,7 @@ const GrazingScheduleEntryRow = ({
           minDate={initialDate}
           maxDate={maxDate}
           aria-label="date out"
+          onChange
         />
       </Table.Cell>
       <Table.Cell collapsing>{utils.handleNullValue(days, false)}</Table.Cell>
@@ -154,7 +144,8 @@ const GrazingScheduleEntryRow = ({
           displayValue={graceDays || (pasture && pasture.graceDays) || 0}
           inputProps={{
             type: 'number',
-            'aria-label': 'grace days'
+            'aria-label': 'grace days',
+            onChange
           }}
           fieldProps={{
             onBlur: e => {

--- a/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleEntryRow.test.js
+++ b/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleEntryRow.test.js
@@ -22,7 +22,8 @@ const schedule = {
       graceDays: 4,
       livestockTypeId: 5,
       livestockCount: 10,
-      id: uuid()
+      id: uuid(),
+      pasture: { id: 1, name: 'Pasture 1', graceDays: 50 }
     }
   ]
 }

--- a/src/components/rangeUsePlanPage/grazingSchedules/__snapshots__/GrazingScheduleEntryRow.test.js.snap
+++ b/src/components/rangeUsePlanPage/grazingSchedules/__snapshots__/GrazingScheduleEntryRow.test.js.snap
@@ -314,7 +314,7 @@ exports[`Grazing Schedule Entry Row Displays each grazing schedule entry 1`] = `
       <td
         class="collapsing"
       >
-        43
+        N/P
       </td>
       <td
         class="collapsing"
@@ -336,12 +336,12 @@ exports[`Grazing Schedule Entry Row Displays each grazing schedule entry 1`] = `
       <td
         class="collapsing"
       >
-        0
+        N/P
       </td>
       <td
         class="collapsing"
       >
-        2.8
+        N/P
       </td>
       <td
         class="collapsing center aligned"

--- a/src/components/rangeUsePlanPage/grazingSchedules/__snapshots__/index.test.js.snap
+++ b/src/components/rangeUsePlanPage/grazingSchedules/__snapshots__/index.test.js.snap
@@ -255,7 +255,7 @@ exports[`Grazing Schedules renders and matches the snapshot 1`] = `
           style="overflow-x: scroll;"
         >
           <table
-            class="ui unstackable ten column table"
+            class="ui sortable unstackable ten column table"
           >
             <thead
               class=""
@@ -305,7 +305,7 @@ exports[`Grazing Schedules renders and matches the snapshot 1`] = `
                   </div>
                 </th>
                 <th
-                  class=""
+                  class="no-sort-tableheader"
                 >
                   Days
                 </th>
@@ -319,12 +319,12 @@ exports[`Grazing Schedules renders and matches the snapshot 1`] = `
                   </div>
                 </th>
                 <th
-                  class=""
+                  class="no-sort-tableheader"
                 >
                   PLD
                 </th>
                 <th
-                  class=""
+                  class="no-sort-tableheader"
                 >
                   Crown AUMs
                 </th>
@@ -332,6 +332,10 @@ exports[`Grazing Schedules renders and matches the snapshot 1`] = `
                   class=""
                 />
               </tr>
+            </thead>
+            <tbody
+              class=""
+            >
               <tr
                 class=""
               >
@@ -695,7 +699,7 @@ exports[`Grazing Schedules renders and matches the snapshot 1`] = `
                   </div>
                 </td>
               </tr>
-            </thead>
+            </tbody>
           </table>
         </div>
         <div
@@ -815,7 +819,7 @@ exports[`Grazing Schedules renders and matches the snapshot 1`] = `
           style="overflow-x: scroll;"
         >
           <table
-            class="ui unstackable bottom attached ten column table"
+            class="ui sortable unstackable bottom attached ten column table"
           >
             <thead
               class=""
@@ -865,7 +869,7 @@ exports[`Grazing Schedules renders and matches the snapshot 1`] = `
                   </div>
                 </th>
                 <th
-                  class=""
+                  class="no-sort-tableheader"
                 >
                   Days
                 </th>
@@ -879,12 +883,12 @@ exports[`Grazing Schedules renders and matches the snapshot 1`] = `
                   </div>
                 </th>
                 <th
-                  class=""
+                  class="no-sort-tableheader"
                 >
                   PLD
                 </th>
                 <th
-                  class=""
+                  class="no-sort-tableheader"
                 >
                   Crown AUMs
                 </th>
@@ -893,6 +897,9 @@ exports[`Grazing Schedules renders and matches the snapshot 1`] = `
                 />
               </tr>
             </thead>
+            <tbody
+              class=""
+            />
           </table>
         </div>
         <div

--- a/src/components/rangeUsePlanPage/grazingSchedules/index.js
+++ b/src/components/rangeUsePlanPage/grazingSchedules/index.js
@@ -17,6 +17,7 @@ import { useReferences } from '../../../providers/ReferencesProvider'
 import { REFERENCE_KEY } from '../../../constants/variables'
 import moment from 'moment'
 import { deleteGrazingSchedule } from '../../../api'
+import { populateGrazingScheduleFields } from '../../../utils/helper/grazingSchedule'
 
 const sortYears = (a, b) => {
   if (a.year > b.year) return 1
@@ -126,7 +127,11 @@ const GrazingSchedules = ({ plan }) => {
                     <GrazingScheduleBox
                       key={schedule.id}
                       yearOptions={yearOptions}
-                      schedule={schedule}
+                      schedule={populateGrazingScheduleFields(
+                        schedule,
+                        plan,
+                        references
+                      )}
                       index={index}
                       onScheduleClicked={() =>
                         setActiveIndex(index !== activeIndex ? index : -1)

--- a/src/styles/Common.scss
+++ b/src/styles/Common.scss
@@ -449,3 +449,10 @@
     }
   }
 }
+
+.no-sort-tableheader {
+  &:hover {
+    background-color: #f9fafb !important;
+    cursor: default !important;
+  }
+}

--- a/src/utils/helper/grazingSchedule.js
+++ b/src/utils/helper/grazingSchedule.js
@@ -1,0 +1,48 @@
+import { REFERENCE_KEY } from '../../constants/variables'
+import {
+  calcDateDiff,
+  calcTotalAUMs,
+  roundTo1Decimal,
+  calcCrownAUMs,
+  calcPldAUMs
+} from '../calculation'
+import moment from 'moment'
+
+export const populateGrazingScheduleFields = (
+  grazingSchedule,
+  plan,
+  references
+) => {
+  const { pastures = [] } = plan
+  const livestockTypes = references[REFERENCE_KEY.LIVESTOCK_TYPE] || []
+
+  return {
+    ...grazingSchedule,
+    grazingScheduleEntries: grazingSchedule.grazingScheduleEntries.map(
+      entry => {
+        const pasture = pastures.find(p => p.id === entry.pastureId)
+        const livestockType = livestockTypes.find(
+          lt => lt.id === entry.livestockTypeId
+        )
+
+        const pldPercent = pasture && pasture.pldPercent
+        const auFactor = livestockType && livestockType.auFactor
+
+        const days = calcDateDiff(entry.dateOut, entry.dateIn, false)
+        const totalAUMs = calcTotalAUMs(entry.livestockCount, days, auFactor)
+        const pldAUMs = roundTo1Decimal(calcPldAUMs(totalAUMs, pldPercent))
+        const crownAUMs = roundTo1Decimal(calcCrownAUMs(totalAUMs, pldAUMs))
+
+        return {
+          ...entry,
+          pasture,
+          livestockType,
+          days,
+          pldAUMs,
+          crownAUMs,
+          createdAtDate: moment(entry.createdAt)
+        }
+      }
+    )
+  }
+}


### PR DESCRIPTION
Allows grazing schedule entries to be sorted, and persists sort configuration.

Relates to #489 
