### PR TITLE
Tweak schedule sort

### DIFF
--- a/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleBox.js
+++ b/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleBox.js
@@ -180,7 +180,7 @@ const GrazingScheduleBox = ({
                     <Table.Header>
                       <Table.Row>
                         <SortableTableHeaderCell
-                          column="pasture"
+                          column="pasture.name"
                           {...headerCellProps}>
                           <div className="rup__grazing-schedule__pasture">
                             {strings.PASTURE}

--- a/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleBox.js
+++ b/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleBox.js
@@ -79,13 +79,21 @@ const GrazingScheduleBox = ({
         orderByColumn('asc', schedule.grazingScheduleEntries)
       )
     } else {
-      const newSortOrder = sortOrder === 'asc' ? 'desc' : 'asc'
-      setSortOrder(newSortOrder)
+      if (sortOrder === 'asc') {
+        setSortOrder('desc')
 
-      formik.setFieldValue(
-        `${namespace}.grazingScheduleEntries`,
-        orderByColumn(newSortOrder, schedule.grazingScheduleEntries)
-      )
+        formik.setFieldValue(
+          `${namespace}.grazingScheduleEntries`,
+          orderByColumn('desc', schedule.grazingScheduleEntries)
+        )
+      } else {
+        setSortOrder(null)
+        setSortBy(null)
+        formik.setFieldValue(
+          `${namespace}.grazingScheduleEntries`,
+          _.orderBy('createdAtDate', 'asc', schedule.grazingScheduleEntries)
+        )
+      }
     }
   }
 


### PR DESCRIPTION
Fixes the pasture sort and allows you to click twice on the header to remove the sort.

Relates to #489