### PR TITLE
Remove createdAt when fields are copied

### DIFF
--- a/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleBox.js
+++ b/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleBox.js
@@ -17,6 +17,7 @@ import { deleteGrazingScheduleEntry } from '../../../api'
 import MultiParagraphDisplay from '../../common/MultiParagraphDisplay'
 import { useUser } from '../../../providers/UserProvider'
 import SortableTableHeaderCell from '../../common/SortableTableHeaderCell'
+import { resetGrazingScheduleEntryId } from '../../../utils/helper/grazingSchedule'
 
 const GrazingScheduleBox = ({
   schedule,
@@ -248,7 +249,9 @@ const GrazingScheduleBox = ({
                             scheduleIndex={index}
                             namespace={`${namespace}.grazingScheduleEntries.${entryIndex}`}
                             onDelete={() => setToRemove(entryIndex)}
-                            onCopy={() => push({ ...entry, id: uuid() })}
+                            onCopy={() =>
+                              push(resetGrazingScheduleEntryId(entry))
+                            }
                             onChange={() => {
                               setSortBy(null)
                             }}

--- a/src/utils/helper/additionalRequirement.js
+++ b/src/utils/helper/additionalRequirement.js
@@ -2,5 +2,6 @@ import uuid from 'uuid-v4'
 
 export const resetAdditionalRequirementId = additionalRequirement => ({
   ...additionalRequirement,
+  createdAt: undefined,
   id: uuid()
 })

--- a/src/utils/helper/grazingSchedule.js
+++ b/src/utils/helper/grazingSchedule.js
@@ -7,6 +7,7 @@ import {
   calcPldAUMs
 } from '../calculation'
 import moment from 'moment'
+import uuid from 'uuid-v4'
 
 export const populateGrazingScheduleFields = (
   grazingSchedule,
@@ -46,3 +47,9 @@ export const populateGrazingScheduleFields = (
     )
   }
 }
+
+export const resetGrazingScheduleEntryId = schedule => ({
+  ...schedule,
+  id: uuid(),
+  createdAt: undefined
+})

--- a/src/utils/helper/pasture.js
+++ b/src/utils/helper/pasture.js
@@ -25,6 +25,7 @@ export const getPastureNames = (pastureIds = [], pasturesMap = {}) => {
 export const resetPastureId = pasture => ({
   ...pasture,
   id: uuid(),
+  createdAt: undefined,
   plantCommunities: pasture.plantCommunities.map(resetPlantCommunityId)
 })
 

--- a/src/utils/helper/plantCommunity.js
+++ b/src/utils/helper/plantCommunity.js
@@ -43,6 +43,7 @@ export const getMonitoringAreaPurposes = (purposes, otherPurpose) => {
 export const resetPlantCommunityId = plantCommunity => ({
   ...plantCommunity,
   id: uuid(),
+  createdAt: undefined,
   indicatorPlants: plantCommunity.indicatorPlants.map(resetIndicatorPlantId),
   monitoringAreas: plantCommunity.monitoringAreas.map(resetMonitoringAreaId),
   plantCommunityActions: plantCommunity.plantCommunityActions.map(
@@ -52,15 +53,18 @@ export const resetPlantCommunityId = plantCommunity => ({
 
 export const resetIndicatorPlantId = indicatorPlant => ({
   ...indicatorPlant,
+  createdAt: undefined,
   id: uuid()
 })
 
 export const resetMonitoringAreaId = monitoringArea => ({
   ...monitoringArea,
+  createdAt: undefined,
   id: uuid()
 })
 
 export const resetPlantCommunityActionId = plantCommunityAction => ({
   ...plantCommunityAction,
+  createdAt: undefined,
   id: uuid()
 })


### PR DESCRIPTION
Prevents copied fields from changing order after save, as they were inheriting the `createdAt` value from the field they were copied from.