### PR TITLE
use same wait command (-F) for both builds

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -47,5 +47,5 @@ jobs:
         export PATH=$PATH_TO_OC
         oc project range-myra-tools
         oc cancel-build bc/range-myra-web-caddy-dev-build
-        oc start-build range-myra-web-caddy-dev-build --wait=true
+        oc start-build range-myra-web-caddy-dev-build -F
         oc tag range-myra-web-caddy:latest range-myra-web-caddy:test


### PR DESCRIPTION
For reasons I can't remember --wait=True was on one of the builds but I don't think that works, plus you don't see errors.