### PR TITLE
update bc to 2500Mi for now to avoid OOMemory errors

### DIFF
--- a/openshift/templates/build.json
+++ b/openshift/templates/build.json
@@ -278,7 +278,7 @@
             "displayName": "Resources Memory Limit",
             "description": "The resources Memory limit (in Mi, Gi, etc) for this build.",
             "required": true,
-            "value": "2Gi"
+            "value": "2500Mi"
         },
         {
             "name": "CPU_REQUEST",
@@ -292,7 +292,7 @@
             "displayName": "Resources Memory Request",
             "description": "The resources Memory request (in Mi, Gi, etc) for this build.",
             "required": true,
-            "value": "2Gi"
+            "value": "2500Mi"
         },
         {
             "name": "GITHUB_SECRET",


### PR DESCRIPTION
Build pods were getting killed at 2Gi, rolling with 2500Mi and will work to optimize.