### PR TITLE
Fix some issues with plant community deletion

### DIFF
--- a/src/components/rangeUsePlanPage/plantCommunities/index.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/index.js
@@ -61,9 +61,7 @@ const PlantCommunities = ({
           </IfEditable>
 
           <Confirm
-            header={`Delete plant community '${plantCommunities[
-              indexToRemove
-            ] && plantCommunities[indexToRemove].name}'`}
+            header={`Delete plant community '${plantCommunities[indexToRemove]?.communityType?.name}'`}
             open={indexToRemove !== null}
             onCancel={() => {
               setIndexToRemove(null)

--- a/src/components/rangeUsePlanPage/plantCommunities/index.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/index.js
@@ -19,7 +19,9 @@ const PlantCommunities = ({
 }) => {
   const isEmpty = plantCommunities.length === 0
   const [activeIndex, setActiveIndex] = useState(-1)
-  const [indexToRemove, setIndexToRemove] = useState(null)
+  const [idToRemove, setIdToRemove] = useState(null)
+
+  const communityToRemove = plantCommunities.find(c => c.id === idToRemove)
 
   return (
     <FieldArray
@@ -61,20 +63,18 @@ const PlantCommunities = ({
           </IfEditable>
 
           <Confirm
-            header={`Delete plant community '${plantCommunities[indexToRemove]?.communityType?.name}'`}
-            open={indexToRemove !== null}
+            header={`Delete plant community '${communityToRemove?.communityType?.name}'`}
+            open={idToRemove !== null}
             onCancel={() => {
-              setIndexToRemove(null)
+              setIdToRemove(null)
             }}
             onConfirm={async () => {
-              const community = plantCommunities[indexToRemove]
-
-              if (!uuid.isUUID(community.id)) {
-                await deletePlantCommunity(planId, pastureId, community.id)
+              if (!uuid.isUUID(idToRemove)) {
+                await deletePlantCommunity(planId, pastureId, idToRemove)
               }
 
-              remove(indexToRemove)
-              setIndexToRemove(null)
+              remove(plantCommunities.indexOf(communityToRemove))
+              setIdToRemove(null)
             }}
           />
 
@@ -95,7 +95,7 @@ const PlantCommunities = ({
                     ? setActiveIndex(-1)
                     : setActiveIndex(index)
                 }}
-                onDelete={() => setIndexToRemove(index)}
+                onDelete={() => setIdToRemove(plantCommunity.id)}
                 namespace={`${namespace}.plantCommunities.${index}`}
               />
             ))}


### PR DESCRIPTION
* Fixes which property is used for the name in the delete modal
* Deletes by ID, rather than index, to prevent deletion of the wrong record.

Relates to #619