### PR TITLE
Change wait command back for caddy build in gh action

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -47,5 +47,5 @@ jobs:
         export PATH=$PATH_TO_OC
         oc project range-myra-tools
         oc cancel-build bc/range-myra-web-caddy-dev-build
-        oc start-build range-myra-web-caddy-dev-build -F
+        oc start-build range-myra-web-caddy-dev-build --wait=true 
         oc tag range-myra-web-caddy:latest range-myra-web-caddy:test


### PR DESCRIPTION
Regular wait command doesn't work for builds using another image stream as input.  Now I know.