### PR TITLE
Fix some bugs with criteria import

### DIFF
--- a/src/components/common/ListModal.js
+++ b/src/components/common/ListModal.js
@@ -30,6 +30,7 @@ const ListModal = ({
         {options.map(option => (
           <List.Item
             key={option.key}
+            disabled={option.disabled}
             onClick={() => {
               if (multiselect) {
                 if (selected.includes(option)) {

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityBox.js
@@ -301,17 +301,31 @@ const PlantCommunityBox = ({
             <IfEditable permission={PLANT_COMMUNITY.IMPORT}>
               <Import
                 excludedPlantCommunityId={plantCommunity.id}
-                onSubmit={({ plantCommunity, criteria }) => {
-                  const indicatorPlants = plantCommunity.indicatorPlants.filter(
-                    ip => {
+                onSubmit={({
+                  plantCommunity: sourcePlantCommunity,
+                  criteria
+                }) => {
+                  const indicatorPlants = sourcePlantCommunity.indicatorPlants
+                    // Filter indicator plants from source plant community based on selected criteria
+                    .filter(ip => {
                       return (
                         (criteria.includes('rangeReadiness') &&
                           ip.criteria === PLANT_CRITERIA.RANGE_READINESS) ||
                         (criteria.includes('stubbleHeight') &&
                           ip.criteria === PLANT_CRITERIA.STUBBLE_HEIGHT)
                       )
-                    }
-                  )
+                    })
+                    // Filter indicator plants from this plant community based on selected criteria
+                    .concat(
+                      plantCommunity.indicatorPlants.filter(ip => {
+                        return (
+                          criteria.includes('rangeReadiness') &&
+                          ip.criteria !== PLANT_CRITERIA.RANGE_READINESS &&
+                          (criteria.includes('stubbleHeight') &&
+                            ip.criteria !== PLANT_CRITERIA.STUBBLE_HEIGHT)
+                        )
+                      })
+                    )
 
                   formik.setFieldValue(
                     `${namespace}.indicatorPlants`,
@@ -321,22 +335,22 @@ const PlantCommunityBox = ({
                   if (criteria.includes('rangeReadiness')) {
                     formik.setFieldValue(
                       `${namespace}.rangeReadinessDay`,
-                      plantCommunity.rangeReadinessDay
+                      sourcePlantCommunity.rangeReadinessDay
                     )
                     formik.setFieldValue(
                       `${namespace}.rangeReadinessMonth`,
-                      plantCommunity.rangeReadinessMonth
+                      sourcePlantCommunity.rangeReadinessMonth
                     )
                     formik.setFieldValue(
                       `${namespace}.rangeReadinessNote`,
-                      plantCommunity.rangeReadinessNote
+                      sourcePlantCommunity.rangeReadinessNote
                     )
                   }
 
                   if (criteria.includes('shrubUse')) {
                     formik.setFieldValue(
                       `${namespace}.shrubUse`,
-                      plantCommunity.shrubUse
+                      sourcePlantCommunity.shrubUse
                     )
                   }
                 }}

--- a/src/components/rangeUsePlanPage/plantCommunities/criteria/Import.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/criteria/Import.js
@@ -1,9 +1,11 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { connect, getIn } from 'formik'
 import ListModal from '../../../common/ListModal'
 import { Button, Confirm, Modal } from 'semantic-ui-react'
 import { oxfordComma } from '../../../../utils'
+import { useReferences } from '../../../../providers/ReferencesProvider'
+import { REFERENCE_KEY } from '../../../../constants/variables'
 
 const initialState = {
   pasture: null,
@@ -19,10 +21,17 @@ const Import = ({ formik, onSubmit, excludedPlantCommunityId }) => {
   const [state, setState] = useState(initialState)
 
   const pastures = getIn(formik.values, 'pastures') || []
+  const communityTypes =
+    useReferences()[REFERENCE_KEY.PLANT_COMMUNITY_TYPE] || []
+
   const pasturesOptions = pastures.map((pasture, index) => ({
     value: pasture.id,
     text: pasture.name || `Unnamed pasture ${index + 1}`,
     key: pasture.id,
+    disabled:
+      pasture.plantCommunities.filter(
+        community => community.id !== excludedPlantCommunityId
+      ).length === 0,
     pasture
   }))
 
@@ -36,7 +45,9 @@ const Import = ({ formik, onSubmit, excludedPlantCommunityId }) => {
       .filter(community => community.id !== excludedPlantCommunityId)
       .map(pc => ({
         value: pc.id,
-        text: pc.name,
+        text:
+          pc.name ??
+          communityTypes.find(type => type.id === pc.communityTypeId)?.name,
         key: pc.id,
         plantCommunity: pc
       }))
@@ -79,12 +90,12 @@ const Import = ({ formik, onSubmit, excludedPlantCommunityId }) => {
         }
         onClose={close}
         onOptionClick={({ plantCommunity }) => {
-          setState({
-            ...state,
+          setState(oldState => ({
+            ...oldState,
             plantCommunity,
             showPlantCommunityModal: false,
             showCriteriaModal: true
-          })
+          }))
         }}
       />
       <ListModal
@@ -110,12 +121,12 @@ const Import = ({ formik, onSubmit, excludedPlantCommunityId }) => {
         ]}
         onClose={close}
         onSubmit={criteria => {
-          setState({
-            ...state,
+          setState(oldState => ({
+            ...oldState,
             showCriteriaModal: false,
             showConfirm: true,
             criteria
-          })
+          }))
         }}
       />
       <Confirm


### PR DESCRIPTION
* Fixes issue where name wouldn't appear when source plant community was unsaved
* Fixes indicator plants being overwritten, even if not part of the selected criteria
* Disables selecting a pasture with no valid plant communities to import from

Relates to #617