### PR TITLE
Fix back button default page

### DIFF
--- a/src/components/rangeUsePlanPage/BackBtn.js
+++ b/src/components/rangeUsePlanPage/BackBtn.js
@@ -7,14 +7,16 @@ import { HOME } from '../../constants/routes'
 const BackBtn = ({ className = '', agreementId }) => {
   const history = useHistory()
 
-  const { page = 1, prevSearch } = history.location.state || {}
+  const { page = 0, prevSearch } = history.location.state || {}
 
   const search = prevSearch ?? `?selected=${agreementId}`
 
   return (
     <div
       className={className}
-      onClick={() => history.push(`${HOME}/${page + 1}${search}`)}
+      onClick={() =>
+        history.push(`${HOME}/${page === 0 ? '' : page + 1}${search}`)
+      }
       role="button"
       tabIndex="0">
       <Icon name="arrow circle left" size="large" />

--- a/src/components/rangeUsePlanPage/schema.js
+++ b/src/components/rangeUsePlanPage/schema.js
@@ -39,7 +39,9 @@ const RUPSchema = Yup.object().shape({
       pldPercent: Yup.number()
         .min(0, 'Please enter a value between 0 and 100')
         .max(1, 'Please enter a value between 0 and 100')
-        .test('whole percent', 'Value must be a whole number', (item) => {return (item * 100) % 1 === 0 ? true : false })
+        .test('whole percent', 'Value must be a whole number', item => {
+          return (item * 100) % 1 === 0 ? true : false
+        })
         .transform((v, originalValue) => (originalValue === '' ? null : v))
         .nullable()
         .typeError('Please enter a number'),


### PR DESCRIPTION
Default page when query parameters couldn't be found was set to 2, causing no agreements to show up when there were only enough results for 1 page.

Relates to #663