### PR TITLE
Change source of staff contact name to agreement

### DIFF
--- a/src/components/selectRangeUsePlanPage/SortableAgreementTable.js
+++ b/src/components/selectRangeUsePlanPage/SortableAgreementTable.js
@@ -240,8 +240,8 @@ export default function SortableAgreementTable({
                       </TableCell>
 
                       <TableCell align="left">
-                        {agreement.plans[0]?.creator
-                          ? `${agreement.plans[0]?.creator?.givenName} ${agreement.plans[0]?.creator?.familyName}`
+                        {agreement.zone?.user
+                          ? `${agreement?.zone?.user?.givenName} ${agreement?.zone?.user?.familyName}`
                           : 'Not provided'}
                       </TableCell>
                       <TableCell align="left">


### PR DESCRIPTION
Staff contact name was previously being pulled from the first plan for each agreement, causing no contact to appear for agreements without a plan. I've reverted it back to the old behaviour of pulling this name from the agreement instead.

Resolves #674 