### PR TITLE
Add more checks for missing references

### DIFF
--- a/src/components/rangeUsePlanPage/basicInformation/index.js
+++ b/src/components/rangeUsePlanPage/basicInformation/index.js
@@ -66,7 +66,7 @@ const BasicInformation = ({ plan, agreement }) => {
             label={strings.AGREEMENT_TYPE}
             text={
               agreementTypes.find(a => a.id === agreement.agreementTypeId)
-                .description
+                ?.description
             }
           />
           <TextField

--- a/src/components/rangeUsePlanPage/index.js
+++ b/src/components/rangeUsePlanPage/index.js
@@ -301,7 +301,6 @@ const mapStateToProps = state => ({
   errorFetchingPlan: selectors.getPlanErrorOccured(state),
   references: selectors.getReferences(state),
   isUpdatingStatus: selectors.getIsUpdatingPlanStatus(state),
-  isCreatingAmendment: selectors.getIsCreatingAmendment(state),
   reAuthRequired: selectors.getReAuthRequired(state)
 })
 

--- a/src/components/rangeUsePlanPage/ministerIssues/MinisterIssueAction.js
+++ b/src/components/rangeUsePlanPage/ministerIssues/MinisterIssueAction.js
@@ -21,9 +21,7 @@ const MinisterIssueAction = ({
   onDelete
 }) => {
   const types = useReferences()[REFERENCE_KEY.MINISTER_ISSUE_ACTION_TYPE] || []
-  const type = types.find(t => t.id === actionTypeId)
-    ? types.find(t => t.id === actionTypeId).name
-    : ''
+  const type = types.find(t => t.id === actionTypeId)?.name ?? ''
   const options = types.map(type => ({
     key: type.id,
     value: type.id,
@@ -112,9 +110,9 @@ const MinisterIssueAction = ({
           displayValue={detail || NO_DESCRIPTION}
           label="Description"
           inputProps={{
-            placeholder: types.find(t => t.id === actionTypeId)
-              ? types.find(t => t.id === actionTypeId).placeholder
-              : types.find(t => t.name === 'Other').placeholder
+            placeholder:
+              types.find(t => t.id === actionTypeId)?.placeholder ??
+              types.find(t => t.name === 'Other')?.placeholder
           }}
         />
       </div>

--- a/src/components/rangeUsePlanPage/pageForAH/index.js
+++ b/src/components/rangeUsePlanPage/pageForAH/index.js
@@ -28,7 +28,8 @@ class PageForAH extends Component {
     isPlanSubmissionModalOpen: false,
     isAHSignatureModalOpen: false,
     isSavingAsDraft: false,
-    isSubmitting: false
+    isSubmitting: false,
+    isCreatingAmendment: false
   }
 
   onSaveDraftClick = () => {
@@ -93,10 +94,20 @@ class PageForAH extends Component {
   onAmendPlanClicked = () => {
     const { plan, fetchPlan, toastSuccessMessage, references } = this.props
 
-    createAmendment(plan, references).then(() => {
-      toastSuccessMessage(strings.CREATE_AMENDMENT_SUCCESS)
-      fetchPlan()
+    this.setState({
+      isCreatingAmendment: true
     })
+
+    createAmendment(plan, references)
+      .then(() => {
+        toastSuccessMessage(strings.CREATE_AMENDMENT_SUCCESS)
+        return fetchPlan()
+      })
+      .then(() => {
+        this.setState({
+          isCreatingAmendment: false
+        })
+      })
   }
 
   validateRup = plan => {
@@ -158,8 +169,8 @@ class PageForAH extends Component {
     this.setState({ isAmendmentSubmissionModalOpen: false })
 
   renderActionBtns = (canEdit, canAmend, canConfirm, canSubmit, canDiscard) => {
-    const { isSavingAsDraft, isSubmitting } = this.state
-    const { isCreatingAmendment, openConfirmationModal } = this.props
+    const { isSavingAsDraft, isSubmitting, isCreatingAmendment } = this.state
+    const { openConfirmationModal } = this.props
 
     return (
       <ActionBtns

--- a/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlant.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/IndicatorPlant.js
@@ -16,9 +16,9 @@ const IndicatorPlant = ({ plant, namespace, valueType, onDelete, formik }) => {
 
   const otherSpecies = species.find(s => s.name === 'Other')
   const [otherType, setOtherType] = useState({
-    key: otherSpecies.id,
-    value: otherSpecies.id,
-    text: plant.name || otherSpecies.name
+    key: otherSpecies?.id,
+    value: otherSpecies?.id,
+    text: plant?.name || otherSpecies?.name || 'Other'
   })
 
   const options = species

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityAction.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityAction.js
@@ -23,9 +23,9 @@ const PlantCommunityAction = ({ action, namespace, onDelete, formik }) => {
 
   const otherType = actionTypes.find(type => type.name === 'Other')
   const [otherOption, setOtherOption] = useState({
-    key: otherType.id,
-    value: otherType.id,
-    text: action.name || otherType.name
+    key: otherType?.id,
+    value: otherType?.id,
+    text: action?.name || otherType?.name || 'Other'
   })
 
   const actionOptions = actionTypes
@@ -99,12 +99,9 @@ const PlantCommunityAction = ({ action, namespace, onDelete, formik }) => {
           inputProps={{
             rows: 5,
             ref: valueInputRef,
-            placeholder: actionTypes.find(
-              type => type.id === action.actionTypeId
-            )
-              ? actionTypes.find(type => type.id === action.actionTypeId)
-                  .placeholder
-              : otherType.placeholder
+            placeholder:
+              actionTypes?.find(type => type.id === action.actionTypeId)
+                ?.placeholder ?? otherType?.placeholder
           }}
         />
 

--- a/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/PlantCommunityBox.js
@@ -135,7 +135,7 @@ const PlantCommunityBox = ({
               component={Dropdown}
               options={communityTypeOptions}
               displayValue={
-                communityType.id === otherType.id ? name : communityType.text
+                communityType?.id === otherType?.id ? name : communityType?.text
               }
               fast
               inputProps={{

--- a/src/components/rangeUsePlanPage/plantCommunities/monitoringArea/MonitoringAreaBox.js
+++ b/src/components/rangeUsePlanPage/plantCommunities/monitoringArea/MonitoringAreaBox.js
@@ -129,9 +129,7 @@ const MonitoringAreaBox = ({
         component={Dropdown}
         options={rangelandHealthOptions}
         displayValue={
-          rangelandHealthTypes.find(r => r.id === rangelandHealthId)
-            ? rangelandHealthTypes.find(r => r.id === rangelandHealthId).name
-            : ''
+          rangelandHealthTypes.find(r => r.id === rangelandHealthId)?.name ?? ''
         }
         label="Rangeland Health"
       />
@@ -148,7 +146,8 @@ const MonitoringAreaBox = ({
         }}
         displayValue={oxfordComma(
           purposeTypeIds.map(
-            purposeTypeId => purposeTypes.find(p => p.id === purposeTypeId).name
+            purposeTypeId =>
+              purposeTypes.find(p => p.id === purposeTypeId)?.name
           )
         )}
         label="Purposes"

--- a/src/reducers/commonStoreReducer.js
+++ b/src/reducers/commonStoreReducer.js
@@ -1,10 +1,20 @@
 import * as actionTypes from '../constants/actionTypes'
 import { getReferencesFromLocalStorage } from '../utils'
+import { REFERENCE_KEY } from '../constants/variables'
+
+const initialReferences = Object.keys(REFERENCE_KEY).reduce(
+  (object, key) => ({
+    ...object,
+    [key]: []
+  }),
+  {}
+)
 
 const initialState = {
-  references: getReferencesFromLocalStorage
-    ? getReferencesFromLocalStorage()
-    : {},
+  references:
+    getReferencesFromLocalStorage && getReferencesFromLocalStorage()
+      ? getReferencesFromLocalStorage()
+      : initialReferences,
   zones: {},
   zoneIds: [],
   users: {},

--- a/src/utils/helper/plan.js
+++ b/src/utils/helper/plan.js
@@ -14,7 +14,7 @@ import { isPlanAmendment } from '../validation'
 const getAmendmentTypeDescription = (amendmentTypeId, amendmentTypes) => {
   if (amendmentTypeId && amendmentTypes) {
     const amendmentType = amendmentTypes.find(at => at.id === amendmentTypeId)
-    return amendmentType.description
+    return amendmentType?.description ?? ''
   }
   return ''
 }

--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -40,4 +40,4 @@ export const saveReferencesInLocalStorage = data => {
 }
 
 export const getReferencesFromLocalStorage = () =>
-  getDataFromLocalStorage(LOCAL_STORAGE_KEY.REFERENCE) || {}
+  getDataFromLocalStorage(LOCAL_STORAGE_KEY.REFERENCE)


### PR DESCRIPTION
The `useReferences` hook is being used like it will always return the correct object of populated references, but this is not always the case since the data is initially retrieved from the API. I've added a default value that sets each key to an empty array, and then also added some checks to the components that consume references.

Relates to #689