### PR TITLE
Set cache header for service worker

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -10,3 +10,7 @@ rewrite {
   if    {path} not_match ^\/0.0.0.0
   to    {path} {path}/ /?_url={uri}
 }
+
+header /service-worker.js {
+  Cache-Control max-age=0,no-cache,no-store,must-revalidate
+}

--- a/Caddyfile
+++ b/Caddyfile
@@ -14,3 +14,7 @@ rewrite {
 header /service-worker.js {
   Cache-Control max-age=0,no-cache,no-store,must-revalidate
 }
+
+header /index.html {
+  Cache-Control max-age=0,no-cache,no-store,must-revalidate
+}


### PR DESCRIPTION
Sets the cache header for `service-worker.js` to try and stop the browser from caching it.