### PR TITLE
Make snapshots on all saves

### DIFF
--- a/src/api/plan.js
+++ b/src/api/plan.js
@@ -116,7 +116,7 @@ export const savePlan = async plan => {
   await saveMinisterIssues(planId, ministerIssues, newPastures)
   await saveAdditionalRequirements(planId, additionalRequirements)
 
-  await createVersion(plan.id)
+  await createVersion(planId)
   return planId
 }
 

--- a/src/api/plan.js
+++ b/src/api/plan.js
@@ -116,6 +116,7 @@ export const savePlan = async plan => {
   await saveMinisterIssues(planId, ministerIssues, newPastures)
   await saveAdditionalRequirements(planId, additionalRequirements)
 
+  await createVersion(plan.id)
   return planId
 }
 
@@ -202,7 +203,7 @@ export const createAmendment = async (plan, references) => {
   )
   const createdStatus = findStatusWithCode(references, PLAN_STATUS.CREATED)
 
-  await createVersion(plan.id)
+  //await createVersion(plan.id)
 
   await axios.put(
     API.UPDATE_RUP(plan.id),


### PR DESCRIPTION
As we'll need to have more statuses than approved getting snapshotted to meet #683 , and we'll have to filter those out anyway for #700 .  This will leave some inaccessible/invisible to user draft snapshots, but I actually want those in there for now for troubleshooting production issues.  We can address storage/retention concerns with a purge rule later.