### PR TITLE
Fetch references on login

### DIFF
--- a/src/actionCreators/commonActionCreator.js
+++ b/src/actionCreators/commonActionCreator.js
@@ -55,9 +55,13 @@ export const fetchReferences = () => (dispatch, getState) => {
       return references
     })
     .catch(err => {
-      console.warn(
-        `Error fetching references, '${err}'. Falling back to locally stored references`
-      )
+      if (err?.status === 401) {
+        // Request was unauthorized, user probably hasn't logged in yet.
+      } else {
+        console.warn(
+          `Error fetching references, '${err}'. Falling back to locally stored references`
+        )
+      }
     })
 }
 

--- a/src/providers/ReferencesProvider.js
+++ b/src/providers/ReferencesProvider.js
@@ -3,15 +3,18 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { getReferences } from '../reducers/rootReducer'
 import { fetchReferences } from '../actionCreators'
+import { useUser } from './UserProvider'
 
 export const ReferencesContext = React.createContext({})
 
 export const useReferences = () => useContext(ReferencesContext)
 
 const ReferencesProvider = ({ references, fetchReferences, children }) => {
+  const user = useUser()
+
   useEffect(() => {
     fetchReferences()
-  }, [])
+  }, [user])
 
   return (
     <ReferencesContext.Provider value={references}>


### PR DESCRIPTION
When you first load MyRange without being signed in, a request is made to fetch the references from the API. The request fails because it was unauthorized, but is not retried after the user logs in. This leads to strange errors stemming from the references not being set in local storage. 

The fix I implemented is to refetch references whenever the `user` object changes (ie. on sign in).

Relates to #719, #720, #715, (maybe) #711