### PR TITLE
Style versions toolbar

### DIFF
--- a/src/components/common/Status.js
+++ b/src/components/common/Status.js
@@ -22,7 +22,7 @@ const defaultProps = {
   style: {}
 }
 
-const Status = ({ status, className, style, user }) => {
+const translateStatusBasedOnUser = (status, user) => {
   let modifier = 'status__icon'
   let statusName = status.code ? 'Unknown_status' : NO_PLAN
 
@@ -159,6 +159,12 @@ const Status = ({ status, className, style, user }) => {
       modifier += '--not-provided'
       break
   }
+
+  return { modifier, statusName }
+}
+
+const Status = ({ status, className, style, user }) => {
+  const { modifier, statusName } = translateStatusBasedOnUser(status, user)
 
   return (
     <div className={classnames('status', className)} style={style}>

--- a/src/components/common/Status.js
+++ b/src/components/common/Status.js
@@ -154,7 +154,6 @@ const translateStatusBasedOnUser = (status, user) => {
       statusName = 'Approved'
       modifier += '--green'
       break
-
     default:
       modifier += '--not-provided'
       break

--- a/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
@@ -119,9 +119,6 @@ const VersionsToolbar = ({
               />
               <Status
                 status={option.version.status}
-                // className={
-                //   option.version.effectiveLegalEnd !== null ? 'greyed' : ''
-                // }
                 className={classnames('versions_status_icon', {
                   greyed: option.version.effectiveLegalEnd !== null
                 })}

--- a/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
@@ -7,13 +7,14 @@ import {
   ListItemAvatar,
   Avatar
 } from '@material-ui/core'
-import Chip from '@material-ui/core/Chip'
 import { withStyles } from '@material-ui/core/styles'
 import { Link } from 'react-router-dom'
 import moment from 'moment'
+import classnames from 'classnames'
 import { RANGE_USE_PLAN } from '../../../constants/routes'
 import { PrimaryButton } from '../../common'
 import VersionToolbar from './VersionToolbar'
+import Status from '../../common/Status'
 
 const VersionsToolbar = ({
   versions,
@@ -47,33 +48,12 @@ const VersionsToolbar = ({
 
   const StyledMenuItem = withStyles(() => ({
     root: {
-      width: 500,
+      width: 550,
       display: 'flex',
       flexDirection: 'row',
       justifyContent: 'flex-start'
     }
   }))(MuiMenuItem)
-
-  const ApprovedChip = withStyles(() => ({
-    root: {
-      backgroundColor: '#8bc34a',
-      color: 'white'
-    }
-  }))(Chip)
-
-  const DisabledApprovedChip = withStyles(() => ({
-    root: {
-      backgroundColor: '#9e9e9e',
-      color: 'white'
-    }
-  }))(Chip)
-
-  const createApprovedChip = current =>
-    current ? (
-      <ApprovedChip label="Approved" />
-    ) : (
-      <DisabledApprovedChip label="Approved" disabled />
-    )
 
   return (
     <>
@@ -103,11 +83,17 @@ const VersionsToolbar = ({
                 handleClose()
               }}>
               <ListItemAvatar>
-                <Avatar>{versionOptions.length - index}</Avatar>
+                <Avatar
+                  style={{
+                    background:
+                      option.version.effectiveLegalEnd === null ? 'green' : null
+                  }}>
+                  {versionOptions.length - index}
+                </Avatar>
               </ListItemAvatar>
               <ListItemText
                 primary={
-                  <div style={{ color: 'grey', width: 200 }}>Legal Start</div>
+                  <div style={{ color: 'grey', width: 250 }}>Legal Start</div>
                 }
                 secondary={
                   <div style={{ color: 'black' }}>
@@ -119,7 +105,7 @@ const VersionsToolbar = ({
               />
               <ListItemText
                 primary={
-                  <div style={{ color: 'grey', width: 200 }}>Legal End</div>
+                  <div style={{ color: 'grey', width: 250 }}>Legal End</div>
                 }
                 secondary={
                   <div style={{ color: 'black' }}>
@@ -131,8 +117,16 @@ const VersionsToolbar = ({
                   </div>
                 }
               />
-              {option.version.status?.name === 'Approved' &&
-                createApprovedChip(option.version.effectiveLegalEnd == null)}
+              <Status
+                status={option.version.status}
+                // className={
+                //   option.version.effectiveLegalEnd !== null ? 'greyed' : ''
+                // }
+                className={classnames('versions_status_icon', {
+                  greyed: option.version.effectiveLegalEnd !== null
+                })}
+                style={{ marginRight: 25 }}
+              />
             </StyledMenuItem>
           ))}
         </MuiMenu>

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -27,8 +27,8 @@ import { isBundled, RETURN_PAGE_TYPE } from './variables'
   API_BASE_URL: 'https://web-range-myra-prod.pathfinder.gov.bc.ca/api'
 }*/
 
-//const DEV_API_BASE_URL = 'https://web-range-myra-dev.pathfinder.gov.bc.ca/api'
-const DEV_API_BASE_URL = 'http://localhost:8080/api'
+const DEV_API_BASE_URL = 'https://web-range-myra-dev.pathfinder.gov.bc.ca/api'
+// const DEV_API_BASE_URL = 'http://localhost:8000/api';
 const DEV = {
   // eslint-disable-line no-unused-vars
   SSO_BASE_URL: 'https://sso-dev.pathfinder.gov.bc.ca',
@@ -36,17 +36,17 @@ const DEV = {
   API_BASE_URL: DEV_API_BASE_URL
 }
 
-const TEST = {
+/*const TEST = {
   // eslint-disable-line no-unused-vars
   SSO_BASE_URL: 'https://sso-test.pathfinder.gov.bc.ca',
   SITEMINDER_BASE_URL: 'https://logontest.gov.bc.ca',
   API_BASE_URL: 'https://web-range-myra-test.pathfinder.gov.bc.ca/api'
-}
+}*/
 
 export const DEV_ENV = {
   // ...PROD,
-  //.DEV
-  ...TEST
+  ...DEV
+  // ...TEST,
 }
 
 export const SSO_BASE_URL = isBundled

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -27,8 +27,8 @@ import { isBundled, RETURN_PAGE_TYPE } from './variables'
   API_BASE_URL: 'https://web-range-myra-prod.pathfinder.gov.bc.ca/api'
 }*/
 
-const DEV_API_BASE_URL = 'https://web-range-myra-dev.pathfinder.gov.bc.ca/api'
-// const DEV_API_BASE_URL = 'http://localhost:8000/api';
+//const DEV_API_BASE_URL = 'https://web-range-myra-dev.pathfinder.gov.bc.ca/api'
+const DEV_API_BASE_URL = 'http://localhost:8080/api'
 const DEV = {
   // eslint-disable-line no-unused-vars
   SSO_BASE_URL: 'https://sso-dev.pathfinder.gov.bc.ca',
@@ -36,17 +36,17 @@ const DEV = {
   API_BASE_URL: DEV_API_BASE_URL
 }
 
-/*const TEST = {
+const TEST = {
   // eslint-disable-line no-unused-vars
   SSO_BASE_URL: 'https://sso-test.pathfinder.gov.bc.ca',
   SITEMINDER_BASE_URL: 'https://logontest.gov.bc.ca',
   API_BASE_URL: 'https://web-range-myra-test.pathfinder.gov.bc.ca/api'
-}*/
+}
 
 export const DEV_ENV = {
   // ...PROD,
-  ...DEV
-  // ...TEST,
+  //.DEV
+  ...TEST
 }
 
 export const SSO_BASE_URL = isBundled

--- a/src/styles/Common.scss
+++ b/src/styles/Common.scss
@@ -39,6 +39,29 @@
   }
 }
 
+.versions_status_icon {
+  .status__icon {
+    margin-top: 2px;
+    min-width: 11px;
+    min-height: 11px; 
+  }
+
+  .status__label {
+    font-size: 16px;
+  }
+}
+
+.greyed {
+  
+  .status__icon {
+    background-color: grey;
+   }
+
+  .status__label {
+    color: grey;
+  }
+}
+
 .text-field {
   margin: 3px 0;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30703259/80619234-47a3ca80-89f9-11ea-9872-a046f186f30c.png)
![image](https://user-images.githubusercontent.com/30703259/80619260-55595000-89f9-11ea-810b-e9d43749ed2b.png)

This PR styles the versions toolbar and contains some relevant information about the status us different versions. I have tried to make the current legal version stand out by colouring the avatar and the approved dot while greying out the other versions.

Does anyone have an RUP number that has multiple versions? I would like to take a look and see what the different statuses look like. As shown above, I could only find versions that had a status of approved.