### PR TITLE
Add amendment button for staff

### DIFF
--- a/src/api/plan.js
+++ b/src/api/plan.js
@@ -18,8 +18,7 @@ import {
   saveMinisterIssues,
   saveAdditionalRequirements,
   savePlantCommunities,
-  savePastures,
-  createVersion
+  savePastures
 } from '.'
 import {
   REFERENCE_KEY,
@@ -198,21 +197,34 @@ export const createNewPlan = agreement => {
 export const updatePlan = async (planId, data) => {
   return await axios.put(API.UPDATE_RUP(planId), data, getAuthHeaderConfig())
 }
+
+export const createAmendment = async (
+  plan,
+  references,
+  staffInitiated = false
+) => {
   const amendmentTypes = references[REFERENCE_KEY.AMENDMENT_TYPE]
   const initialAmendment = amendmentTypes.find(
     at => at.code === AMENDMENT_TYPE.INITIAL
   )
   const createdStatus = findStatusWithCode(references, PLAN_STATUS.CREATED)
-
-  //await createVersion(plan.id)
+  const staffDraftStatus = findStatusWithCode(
+    references,
+    PLAN_STATUS.STAFF_DRAFT
+  )
 
   await axios.put(
     API.UPDATE_RUP(plan.id),
     {
       ...plan,
-      statusId: createdStatus.id,
       amendmentTypeId: initialAmendment.id
     },
+    getAuthHeaderConfig()
+  )
+
+  await axios.put(
+    API.UPDATE_PLAN_STATUS(plan.id),
+    { statusId: staffInitiated ? staffDraftStatus.id : createdStatus.id },
     getAuthHeaderConfig()
   )
 

--- a/src/api/plan.js
+++ b/src/api/plan.js
@@ -195,7 +195,9 @@ export const createNewPlan = agreement => {
   return newPlan
 }
 
-export const createAmendment = async (plan, references) => {
+export const updatePlan = async (planId, data) => {
+  return await axios.put(API.UPDATE_RUP(planId), data, getAuthHeaderConfig())
+}
   const amendmentTypes = references[REFERENCE_KEY.AMENDMENT_TYPE]
   const initialAmendment = amendmentTypes.find(
     at => at.code === AMENDMENT_TYPE.INITIAL

--- a/src/components/rangeUsePlanPage/ActionBtns.js
+++ b/src/components/rangeUsePlanPage/ActionBtns.js
@@ -117,8 +117,7 @@ const ActionBtns = ({
     <>
       {canEdit && saveDraftBtn}
       {canSubmit && submitBtn}
-      {/* TODO: Re-enable amendment buttons once workflows have been completed */}
-      {/* {canAmend && amendBtn} */}
+      {canAmend && amendBtn}
       {canConfirm && confirmSubmissionBtn}
       {canDiscard && <DiscardAmendmentButton />}
       <Dropdown

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -243,11 +243,7 @@ class PageForStaff extends Component {
               <div className="rup__actions__left">
                 <BackBtn className="rup__back-btn" agreementId={agreementId} />
                 <div>{agreementId}</div>
-                <Status
-                  status={status}
-                  user={user}
-                  amendmentTypeId={plan.amendmentTypeId}
-                />
+                <Status status={status} user={user} />
                 <NetworkStatus planId={plan.id} />
                 <div>{utils.capitalize(rangeName)}</div>
               </div>

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -1,6 +1,10 @@
 import React, { Component } from 'react'
 import UpdateZoneModal from './UpdateZoneModal'
-import { REFERENCE_KEY, PLAN_STATUS } from '../../../constants/variables'
+import {
+  REFERENCE_KEY,
+  PLAN_STATUS,
+  AMENDMENT_TYPE
+} from '../../../constants/variables'
 import { Status, Banner } from '../../common'
 import * as strings from '../../../constants/strings'
 import * as utils from '../../../utils'
@@ -13,7 +17,7 @@ import ActionBtns from '../ActionBtns'
 import UpdateStatusModal from './UpdateStatusModal'
 import PlanForm from '../PlanForm'
 import { canUserEditThisPlan } from '../../../utils'
-import { savePlan } from '../../../api'
+import { createAmendment, savePlan, updatePlan } from '../../../api'
 import NetworkStatus from '../../common/NetworkStatus'
 
 // Range Staff Page
@@ -95,6 +99,41 @@ class PageForStaff extends Component {
     this.props.history.push(`/range-use-plan/${planId}/versions`)
   }
 
+  onAmendPlanClicked = async () => {
+    const {
+      plan,
+      fetchPlan,
+      toastSuccessMessage,
+      toastErrorMessage,
+      references
+    } = this.props
+
+    this.setState({
+      isCreatingAmendment: true
+    })
+
+    try {
+      const amendmentType = references[REFERENCE_KEY.AMENDMENT_TYPE]?.find(
+        type => type.code === AMENDMENT_TYPE.MANDATORY
+      )
+
+      await createAmendment(plan, references, true)
+      await updatePlan(plan.id, {
+        amendmentTypeId: amendmentType.id
+      })
+
+      toastSuccessMessage(strings.CREATE_AMENDMENT_SUCCESS)
+    } catch (e) {
+      toastErrorMessage(`Couldn't create amendment: ${e.message}`)
+    } finally {
+      this.setState({
+        isCreatingAmendment: false
+      })
+
+      await fetchPlan()
+    }
+  }
+
   openUpdateZoneModal = () => this.setState({ isUpdateZoneModalOpen: true })
   closeUpdateZoneModal = () => this.setState({ isUpdateZoneModalOpen: false })
   openPlanSubmissionModal = () => {
@@ -108,13 +147,15 @@ class PageForStaff extends Component {
   closePlanSubmissionModal = () =>
     this.setState({ isPlanSubmissionModalOpen: false })
 
-  renderActionBtns = (canEdit, canSubmit) => {
+  renderActionBtns = (canEdit, canSubmit, canAmend) => {
     const { isSavingAsDraft, isSubmitting } = this.state
+    const { openConfirmationModal } = this.props
 
     return (
       <ActionBtns
         canEdit={canEdit}
         canSubmit={canSubmit}
+        canAmend={canAmend}
         canDiscard={false}
         isSubmitting={isSubmitting}
         isSavingAsDraft={isSavingAsDraft}
@@ -126,6 +167,8 @@ class PageForStaff extends Component {
         isFetchingPlan={this.props.isFetchingPlan}
         fetchPlan={this.props.fetchPlan}
         canUpdateStatus
+        openConfirmationModal={openConfirmationModal}
+        onAmendPlanClicked={this.onAmendPlanClicked}
         beforeUpdateStatus={async () => {
           await savePlan(this.props.plan)
           await this.props.fetchPlan()
@@ -159,6 +202,7 @@ class PageForStaff extends Component {
 
     const canEdit = utils.canUserEditThisPlan(plan, user)
     const canSubmit = utils.canUserSubmitPlan(plan, user)
+    const canAmend = utils.isStatusAmongApprovedStatuses(status)
 
     const amendmentTypes = references[REFERENCE_KEY.AMENDMENT_TYPE]
     const planTypeDescription = utils.getPlanTypeDescription(
@@ -199,12 +243,16 @@ class PageForStaff extends Component {
               <div className="rup__actions__left">
                 <BackBtn className="rup__back-btn" agreementId={agreementId} />
                 <div>{agreementId}</div>
-                <Status status={status} user={user} />
+                <Status
+                  status={status}
+                  user={user}
+                  amendmentTypeId={plan.amendmentTypeId}
+                />
                 <NetworkStatus planId={plan.id} />
                 <div>{utils.capitalize(rangeName)}</div>
               </div>
               <div className="rup__actions__btns">
-                {this.renderActionBtns(canEdit, canSubmit)}
+                {this.renderActionBtns(canEdit, canSubmit, canAmend)}
               </div>
             </div>
           </div>


### PR DESCRIPTION
This PR unhides the amendment button, and gives the ability for staff to initiate a mandatory amendment from approved plans. There's still some wonkiness around discarding right now, but that should be addressed by #760 

Relates to #756