### PR TITLE
Allow staff to discard mandatory amendments they initiate

### DIFF
--- a/src/components/rangeUsePlanPage/ActionBtns.js
+++ b/src/components/rangeUsePlanPage/ActionBtns.js
@@ -117,8 +117,7 @@ const ActionBtns = ({
     <>
       {canEdit && saveDraftBtn}
       {canSubmit && submitBtn}
-      {/* TODO: Re-enable amendment buttons once workflows have been completed */}
-      {/* {canAmend && amendBtn} */}
+      {canAmend && amendBtn}
       {canConfirm && confirmSubmissionBtn}
       {canDiscard && <DiscardAmendmentButton />}
       <Dropdown

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -147,7 +147,7 @@ class PageForStaff extends Component {
   closePlanSubmissionModal = () =>
     this.setState({ isPlanSubmissionModalOpen: false })
 
-  renderActionBtns = (canEdit, canSubmit, canAmend) => {
+  renderActionBtns = (canEdit, canSubmit, canAmend, canDiscard) => {
     const { isSavingAsDraft, isSubmitting } = this.state
     const { openConfirmationModal } = this.props
 
@@ -156,7 +156,7 @@ class PageForStaff extends Component {
         canEdit={canEdit}
         canSubmit={canSubmit}
         canAmend={canAmend}
-        canDiscard={false}
+        canDiscard={canDiscard}
         isSubmitting={isSubmitting}
         isSavingAsDraft={isSavingAsDraft}
         onViewPDFClicked={this.onViewPDFClicked}
@@ -203,6 +203,7 @@ class PageForStaff extends Component {
     const canEdit = utils.canUserEditThisPlan(plan, user)
     const canSubmit = utils.canUserSubmitPlan(plan, user)
     const canAmend = utils.isStatusAmongApprovedStatuses(status)
+    const canDiscard = utils.canUserDiscardAmendment(plan, user)
 
     const amendmentTypes = references[REFERENCE_KEY.AMENDMENT_TYPE]
     const planTypeDescription = utils.getPlanTypeDescription(
@@ -252,7 +253,12 @@ class PageForStaff extends Component {
                 <div>{utils.capitalize(rangeName)}</div>
               </div>
               <div className="rup__actions__btns">
-                {this.renderActionBtns(canEdit, canSubmit, canAmend)}
+                {this.renderActionBtns(
+                  canEdit,
+                  canSubmit,
+                  canAmend,
+                  canDiscard
+                )}
               </div>
             </div>
           </div>

--- a/src/utils/helper/plan.js
+++ b/src/utils/helper/plan.js
@@ -5,7 +5,8 @@ import {
   FEEDBACK_REQUIRED_FROM_STAFF_PLAN_STATUSES,
   REQUIRE_NOTES_PLAN_STATUSES,
   NOT_DOWNLOADABLE_PLAN_STATUSES,
-  REFERENCE_KEY
+  REFERENCE_KEY,
+  USER_ROLE
 } from '../../constants/variables'
 import { isAmendment } from './amendment'
 import { isUserAgreementHolder } from './user'
@@ -187,14 +188,20 @@ export const canUserEditThisPlan = (plan = {}, user = {}) => {
   return false
 }
 
-export const canUserDiscardAmendment = plan => {
+export const canUserDiscardAmendment = (plan, user) => {
   const isAmendment = isPlanAmendment(plan)
 
-  return (
-    isAmendment &&
-    !isStatusStands(plan.status) &&
-    !isStatusStandsWM(plan.status)
-  )
+  if (!user || !plan) return false
+
+  if (user.roles.includes(USER_ROLE.RANGE_OFFICER)) {
+    return isAmendment && isStatusStaffDraft(plan.status)
+  }
+
+  if (user.roles.includes(USER_ROLE.AGREEMENT_HOLDER)) {
+    return isAmendment && isStatusCreated(plan.status)
+  }
+
+  return false
 }
 
 export const findStatusWithCode = (references, statusCode) => {


### PR DESCRIPTION
Enables the discard button for staff after they create a mandatory amendment, and hides it when they submit it to the AH.

Relates to #760