### PR TITLE
Show all stands as stands

### DIFF
--- a/src/components/common/Status.js
+++ b/src/components/common/Status.js
@@ -23,7 +23,11 @@ const defaultProps = {
   style: {}
 }
 
-const translateStatusBasedOnUser = (status, user) => {
+const translateStatusBasedOnUser = (
+  status,
+  user,
+  isForVersionsList = false
+) => {
   let modifier = 'status__icon'
   let statusName = status.code ? 'Unknown_status' : NO_PLAN
 
@@ -68,7 +72,11 @@ const translateStatusBasedOnUser = (status, user) => {
       modifier += '--red'
       break
     case PLAN_STATUS.STANDS_WRONGLY_MADE:
-      statusName = 'Wrongly Made Stands'
+      if (isForVersionsList) {
+        statusName = 'Stands'
+      } else {
+        statusName = 'Wrongly Made Stands'
+      }
       modifier += '--green'
       break
     case PLAN_STATUS.STANDS_REVIEW:
@@ -81,12 +89,17 @@ const translateStatusBasedOnUser = (status, user) => {
       }
       break
     case PLAN_STATUS.STANDS_NOT_REVIEWED:
-      if (isUserAgreementHolder(user)) {
+      if (isForVersionsList) {
         statusName = 'Stands'
         modifier += '--green'
       } else {
-        statusName = 'Stands - Not Reviewed'
-        modifier += '--green'
+        if (isUserAgreementHolder(user)) {
+          statusName = 'Stands'
+          modifier += '--green'
+        } else {
+          statusName = 'Stands - Not Reviewed'
+          modifier += '--green'
+        }
       }
       break
     case PLAN_STATUS.STANDS:

--- a/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
@@ -121,7 +121,7 @@ const VersionsToolbar = ({
                 }
                 secondary={
                   <div style={{ color: 'black' }}>
-                    {moment(option.version.effectiveLegalStart).format(
+                    {moment(option.version.effectiveLegalEnd).format(
                       'MMM DD YYYY'
                     )}
                   </div>

--- a/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
@@ -15,6 +15,7 @@ import { RANGE_USE_PLAN } from '../../../constants/routes'
 import { PrimaryButton } from '../../common'
 import VersionToolbar from './VersionToolbar'
 import Status from '../../common/Status'
+import { useUser } from '../../../providers/UserProvider'
 
 const VersionsToolbar = ({
   versions,
@@ -23,6 +24,7 @@ const VersionsToolbar = ({
   planId
 }) => {
   const [anchorEl, setAnchorEl] = useState(null)
+  const user = useUser()
 
   const handleClose = () => setAnchorEl(null)
   const handleOpen = event => setAnchorEl(event.currentTarget)
@@ -129,8 +131,8 @@ const VersionsToolbar = ({
               />
               <Status
                 status={option.version.status}
-		user={user}
-		isForVersionsList={true}
+                user={user}
+                isForVersionsList={true}
                 className={classnames('versions_status_icon', {
                   greyed: option.version.isCurrentLegalVersion === false
                 })}

--- a/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
@@ -33,18 +33,6 @@ const VersionsToolbar = ({
     key: v.version,
     value: v,
     text: `v${v.version}`,
-    content: (
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '40px repeat(2, auto)',
-          gridTemplateRows: '1fr'
-        }}>
-        <span>v{v.version}</span>
-        <span>{v.status.name}</span>
-        <span>{moment(v.createdAt).format('MMM DD, YYYY, h:mm:ss a')}</span>
-      </div>
-    ),
     version: v
   }))
 

--- a/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
@@ -129,6 +129,8 @@ const VersionsToolbar = ({
               />
               <Status
                 status={option.version.status}
+		user={user}
+		isForVersionsList={true}
                 className={classnames('versions_status_icon', {
                   greyed: option.version.isCurrentLegalVersion === false
                 })}


### PR DESCRIPTION
In order to show the right start date for any Stands legal version, we need to (for now) hide the exact stage it's in (reviewed etc).  

- This change makes sure the status component gets passed user (from context) and that the status component only renders 'Stands' when that is applicable.  
- Fix legal end date pulling start date.
- Also some cleanup of unused content.