### PR TITLE
Tidy up versions menu

### DIFF
--- a/src/components/rangeUsePlanPage/versionsList/VersionsDropdownList.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsDropdownList.js
@@ -33,6 +33,7 @@ const VersionsDropdownList = ({ versions, open }) => {
             <Table size="small" aria-label="dates">
               <TableHead>
                 <TableRow>
+                  <TableCell style={{ color: 'grey' }}>Reason</TableCell>
                   <TableCell style={{ color: 'grey' }}>Legal Start</TableCell>
                   <TableCell style={{ color: 'grey' }}>Legal End</TableCell>
                   <TableCell style={{ color: 'grey', align: 'left' }}>
@@ -43,7 +44,9 @@ const VersionsDropdownList = ({ versions, open }) => {
               <TableBody>
                 {versionOptions.map((option, index) => (
                   <TableRow key={index} hover={true}>
-                    <TableCell component="th" scope="row">
+                    <TableCell>{option.version.legalReason}</TableCell>
+
+                    <TableCell>
                       {moment(option.version.effectiveLegalStart).format(
                         'MMM DD YYYY h:mm a'
                       )}
@@ -57,8 +60,8 @@ const VersionsDropdownList = ({ versions, open }) => {
                     </TableCell>
                     <TableCell>
                       <Status
-                        className={classnames({
-                          greyed: option.version.effectiveLegalEnd !== null
+                        className={classnames('versions_status_icon', {
+                          greyed: option.version.isCurrentLegalVersion === false
                         })}
                         status={option.version.status}
                         user={user}

--- a/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
@@ -84,7 +84,7 @@ const VersionsToolbar = ({
                 </Avatar>
               </ListItemAvatar>
               <ListItemText
-                style={{ width: 60, marginLeft: 5 }}
+                style={{ width: 65, marginLeft: 5 }}
                 primary={<div style={{ color: 'grey' }}>Reason</div>}
                 secondary={
                   <div style={{ color: 'black', height: 20 }}>

--- a/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
@@ -84,19 +84,15 @@ const VersionsToolbar = ({
                 </Avatar>
               </ListItemAvatar>
               <ListItemText
-                primary={
-                  <div style={{ color: 'grey', width: 250 }}>Reason</div>
-                }
+                primary={<div style={{ color: 'grey' }}>Reason</div>}
                 secondary={
-                  <div style={{ color: 'black' }}>
+                  <div style={{ color: 'black', height: 20 }}>
                     {option.version.legalReason}
                   </div>
                 }
               />
               <ListItemText
-                primary={
-                  <div style={{ color: 'grey', width: 250 }}>Legal Start</div>
-                }
+                primary={<div style={{ color: 'grey' }}>Legal Start</div>}
                 secondary={
                   <div style={{ color: 'black' }}>
                     {moment(option.version.effectiveLegalStart).format(
@@ -106,9 +102,7 @@ const VersionsToolbar = ({
                 }
               />
               <ListItemText
-                primary={
-                  <div style={{ color: 'grey', width: 250 }}>Legal End</div>
-                }
+                primary={<div style={{ color: 'grey' }}>Legal End</div>}
                 secondary={
                   <div style={{ color: 'black' }}>
                     {moment(option.version.effectiveLegalEnd).format(

--- a/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
@@ -84,6 +84,7 @@ const VersionsToolbar = ({
                 </Avatar>
               </ListItemAvatar>
               <ListItemText
+                style={{ width: 55 }}
                 primary={<div style={{ color: 'grey' }}>Reason</div>}
                 secondary={
                   <div style={{ color: 'black', height: 20 }}>

--- a/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
+++ b/src/components/rangeUsePlanPage/versionsList/VersionsToolbar.js
@@ -84,7 +84,7 @@ const VersionsToolbar = ({
                 </Avatar>
               </ListItemAvatar>
               <ListItemText
-                style={{ width: 55 }}
+                style={{ width: 60, marginLeft: 5 }}
                 primary={<div style={{ color: 'grey' }}>Reason</div>}
                 secondary={
                   <div style={{ color: 'black', height: 20 }}>


### PR DESCRIPTION
 - Aligned the Reason label when no reason is shown
 - Evened out spacing between Reason, Legal Start and Legal End

### Before:
![image](https://user-images.githubusercontent.com/30703259/82700875-eea80a80-9c23-11ea-9f35-c888604980d8.png)

### After:
![image](https://user-images.githubusercontent.com/30703259/82701742-96720800-9c25-11ea-9e83-1654f4d3af39.png)

