### PR TITLE
Allow mandatory amendment to be amended from legal in Not Approved

### DIFF
--- a/src/api/plan.js
+++ b/src/api/plan.js
@@ -219,7 +219,6 @@ export const createAmendment = async (
   await axios.put(
     API.UPDATE_RUP(plan.id),
     {
-      ...plan,
       amendmentTypeId: initialAmendment.id
     },
     getAuthHeaderConfig()

--- a/src/utils/helper/plan.js
+++ b/src/utils/helper/plan.js
@@ -198,7 +198,6 @@ export const canUserEditThisPlan = (plan = {}, user = {}) => {
     isStatusCreated(status) ||
     isStatusDraft(status) ||
     isStatusChangedRequested(status) ||
-    isStatusNotApproved(status) ||
     isStatusNotApprovedFWR(status) ||
     isStatusRecommendForSubmission(status) ||
     isStatusAmendmentAH(status)
@@ -226,7 +225,7 @@ export const canUserDiscardAmendment = (plan, user) => {
 export const canUserAmendFromLegal = (plan, user) => {
   if (!user || !plan) return false
 
-  return isStatusWronglyMakeWE(plan.status)
+  return isStatusWronglyMakeWE(plan.status) || isStatusNotApproved(plan.status)
 }
 
 export const canUserSubmitAsMandatory = (plan, user) => {


### PR DESCRIPTION
Allows the user to amend from the past legal version when the current plan is a  not approved mandatory amendment, similar to the functionality with WMWE.

Relates to #822