### PR TITLE
Create manage agents page

### DIFF
--- a/src/components/rangeUsePlanPage/ActionBtns.js
+++ b/src/components/rangeUsePlanPage/ActionBtns.js
@@ -23,6 +23,7 @@ const ActionBtns = ({
   isCreatingAmendment,
   onViewPDFClicked,
   onViewVersionsClicked,
+  onManageAgentsClicked,
   onSubmit,
   onSignSubmission,
   onAmend,
@@ -98,6 +99,12 @@ const ActionBtns = ({
       {VIEW_VERSIONS}
     </Menu.Item>
   )
+  const manageAgentsMenuItem = (
+    <Menu.Item key="manageAgentsBtn" onClick={onManageAgentsClicked}>
+      <Icon name="user" />
+      Manage Agents
+    </Menu.Item>
+  )
 
   const permissions = {
     edit: false,
@@ -108,6 +115,7 @@ const ActionBtns = ({
     updateStatus: false,
     discard: false,
     submitAsMandatory: false,
+    manageAgents: false,
     ...permissionsOptions
   }
 
@@ -133,6 +141,7 @@ const ActionBtns = ({
         <Dropdown.Menu>
           {downloadPDFBtn}
           {viewVersionsMenuItem}
+          {permissions.manageAgents && manageAgentsMenuItem}
           {permissions.updateStatus && (
             <UpdateStatusDropdown
               plan={plan}
@@ -155,7 +164,8 @@ ActionBtns.propTypes = {
     updateStatus: PropTypes.bool,
     discard: PropTypes.bool,
     submitAsMandatory: PropTypes.bool,
-    amendFromLegal: PropTypes.bool
+    amendFromLegal: PropTypes.bool,
+    manageAgents: PropTypes.bool
   }),
   onViewPDFClicked: PropTypes.func,
   onViewVersionsClicked: PropTypes.func,

--- a/src/components/rangeUsePlanPage/manageAgentsPage/index.js
+++ b/src/components/rangeUsePlanPage/manageAgentsPage/index.js
@@ -1,0 +1,175 @@
+import React, { useEffect, useState } from 'react'
+import * as API from '../../../constants/api'
+import { Loading, PrimaryButton } from '../../common'
+import useSWR from 'swr'
+import { getAuthHeaderConfig, axios, getUserFullName } from '../../../utils'
+import { Autocomplete } from '@material-ui/lab'
+import PersonIcon from '@material-ui/icons/Person'
+import { Grid } from 'semantic-ui-react'
+import { Typography, TextField, makeStyles } from '@material-ui/core'
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    alignItems: 'center'
+  },
+  icon: {
+    color: theme.palette.text.secondary,
+    marginRight: theme.spacing(2)
+  },
+  container: {
+    maxWidth: 800,
+    width: '100%'
+  },
+  autocomplete: {
+    width: 400
+  },
+  autocompleteOption: {
+    height: 100
+  },
+  row: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    width: '100%',
+    marginBottom: 30
+  }
+}))
+
+const fetcher = key =>
+  axios.get(key, getAuthHeaderConfig()).then(res => res.data)
+
+const ManageAgentsPage = ({ match }) => {
+  const classes = useStyles()
+  const [clientAgreements, setClientAgreements] = useState(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const [errorSaving, setErrorSaving] = useState(null)
+
+  const { planId } = match.params
+
+  const { data, isValidating: isValidatingClients, error } = useSWR(
+    API.GET_CLIENT_AGREEMENTS(planId),
+    fetcher
+  )
+
+  const { data: users, isValidating: isValidatingUsers } = useSWR(
+    `${API.GET_USERS}/?orderCId=desc&excludeBy=username&exclude=idir`,
+    fetcher
+  )
+
+  useEffect(() => {
+    if (!clientAgreements) {
+      setClientAgreements(data)
+    }
+  }, [data])
+
+  const handleSave = async () => {
+    setIsSaving(true)
+    try {
+      for (const clientAgreement of clientAgreements) {
+        await axios.put(
+          API.UPDATE_CLIENT_AGREEMENT(planId, clientAgreement.id),
+          { agentId: clientAgreement.agent?.id ?? null },
+          getAuthHeaderConfig()
+        )
+      }
+    } catch (e) {
+      setErrorSaving(e)
+    }
+
+    setIsSaving(false)
+  }
+
+  if (error) {
+    return <span>Error: {error?.message}</span>
+  }
+
+  if (
+    (!clientAgreements && isValidatingClients) ||
+    (!users && isValidatingUsers)
+  ) {
+    return <Loading />
+  }
+
+  if (clientAgreements) {
+    return (
+      <div className={classes.root}>
+        <div className={classes.container}>
+          <h1>Manage agents</h1>
+          {clientAgreements.map(clientAgreement => (
+            <div key={clientAgreement.id} className={classes.row}>
+              <div>
+                {clientAgreement.client.name}{' '}
+                {clientAgreement.client.clientNumber}-
+                {clientAgreement.client.locationCode}
+              </div>
+              <div>
+                <Autocomplete
+                  id="user-autocomplete-select"
+                  options={users}
+                  value={clientAgreement.agent}
+                  openOnFocus
+                  onChange={(e, user) => {
+                    setClientAgreements(c =>
+                      c.map(ca =>
+                        ca.id === clientAgreement.id
+                          ? {
+                              ...ca,
+                              agent: user
+                            }
+                          : ca
+                      )
+                    )
+                  }}
+                  getOptionLabel={option => getUserFullName(option)}
+                  getOptionSelected={option =>
+                    option.id === clientAgreement.agentId
+                  }
+                  style={{ width: 300 }}
+                  renderInput={params => (
+                    <TextField
+                      {...params}
+                      label="Select user"
+                      variant="outlined"
+                      fullWidth
+                      className={classes.autocomplete}
+                    />
+                  )}
+                  renderOption={option => {
+                    return (
+                      <Grid
+                        container
+                        alignItems="center"
+                        className={classes.autocompleteOption}>
+                        <Grid item>
+                          <PersonIcon className={classes.icon} />
+                        </Grid>
+                        <Grid item xs>
+                          {getUserFullName(option)}
+
+                          <Typography variant="body2" color="textSecondary">
+                            {option.email}
+                          </Typography>
+                        </Grid>
+                      </Grid>
+                    )
+                  }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+        {isSaving && <Loading />}
+        <PrimaryButton onClick={handleSave}>Save</PrimaryButton>
+        {errorSaving && <span>Error: {errorSaving?.message}</span>}
+      </div>
+    )
+  }
+
+  return <Loading />
+}
+
+export default ManageAgentsPage

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -101,6 +101,11 @@ class PageForStaff extends Component {
     this.props.history.push(`/range-use-plan/${planId}/versions`)
   }
 
+  onManageAgentsClicked = () => {
+    const { id: planId } = this.props.plan || []
+    this.props.history.push(`/range-use-plan/${planId}/agents`)
+  }
+
   onAmendPlanClicked = async () => {
     const {
       plan,
@@ -163,7 +168,8 @@ class PageForStaff extends Component {
           discard: utils.canUserDiscardAmendment(plan, user),
           updateStatus: true,
           submitAsMandatory: utils.canUserSubmitAsMandatory(plan, user),
-          amendFromLegal: utils.canUserAmendFromLegal(plan, user)
+          amendFromLegal: utils.canUserAmendFromLegal(plan, user),
+          manageAgents: true
         }}
         isSubmitting={isSubmitting}
         isSavingAsDraft={isSavingAsDraft}
@@ -171,6 +177,7 @@ class PageForStaff extends Component {
         isCreatingAmendment={this.state.isCreatingAmendment}
         onViewPDFClicked={this.onViewPDFClicked}
         onViewVersionsClicked={this.onViewVersionsClicked}
+        onManageAgentsClicked={this.onManageAgentsClicked}
         onSaveDraftClick={this.onSaveDraftClick}
         onSubmit={async () => {
           this.setState({ isSubmitting: true })

--- a/src/components/router/index.js
+++ b/src/components/router/index.js
@@ -29,6 +29,7 @@ import { LoadableComponent } from './LoadableComponent'
 import VersionsList from '../rangeUsePlanPage/versionsList/VersionsList'
 import { QueryParamProvider } from 'use-query-params'
 import ErrorBoundary from '../common/ErrorBoundary'
+import ManageAgentsPage from '../rangeUsePlanPage/manageAgentsPage'
 
 const SelectRangeUsePlan = LoadableComponent(() =>
   import('../selectRangeUsePlanPage')
@@ -78,6 +79,11 @@ const Router = () => {
             <ProtectedRoute
               path={Routes.VIEW_PLAN_VERSIONS}
               component={VersionsList}
+              user={user}
+            />
+            <ProtectedRoute
+              path={Routes.MANAGE_PLAN_AGENTS}
+              component={ManageAgentsPage}
               user={user}
             />
             <ProtectedRoute

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -87,6 +87,9 @@ export const DELETE_USER_CLIENT_LINK = (userId, clientId) =>
 export const CREATE_RUP = '/v1/plan'
 export const GET_RUP = planId => `/v1/plan/${planId}`
 export const GET_PLAN_PDF = planId => `/v1/report/${planId}`
+export const GET_CLIENT_AGREEMENTS = planId => `/v1/client/agreements/${planId}`
+export const UPDATE_CLIENT_AGREEMENT = (planId, clientAgreementId) =>
+  `/v1/client/agreements/${planId}/${clientAgreementId}`
 export const UPDATE_PLAN_STATUS = planId => `/v1/plan/${planId}/status`
 export const UPDATE_RUP = planId => `/v1/plan/${planId}`
 export const UPDATE_CONFIRMATION = (planId, confirmationId) =>

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -6,6 +6,7 @@ export const RANGE_USE_PLAN = '/range-use-plan'
 export const EXPORT_PDF = '/export-pdf'
 export const EXPORT_PDF_WITH_PARAM = '/range-use-plan/:planId/export-pdf/'
 export const VIEW_PLAN_VERSIONS = '/range-use-plan/:planId/versions/:version?'
+export const MANAGE_PLAN_AGENTS = '/range-use-plan/:planId/agents'
 export const RANGE_USE_PLAN_WITH_PARAM = '/range-use-plan/:planId'
 
 export const MANAGE_ZONE = '/manage-zone'


### PR DESCRIPTION
Adds a page, accessible by the 3-dot menu on the RUP page, to allow staff to manage agents for clients for a plan/agreement.

Relies on https://github.com/bcgov/range-api/pull/234.
Relates to #857