### PR TITLE
Allow agents to sign plans

### DIFF
--- a/src/actionCreators/planActionCreator.js
+++ b/src/actionCreators/planActionCreator.js
@@ -126,9 +126,11 @@ export const createRUPStatusRecord = (plan, newStatus, note) => (
 
 export const updateRUPConfirmation = (
   plan,
+  user,
   confirmationId,
   confirmed,
-  isMinorAmendment
+  isMinorAmendment,
+  isOwnSignature = true
 ) => (dispatch, getState) => {
   const { id: planId } = plan
   const config = {
@@ -139,7 +141,11 @@ export const updateRUPConfirmation = (
   }
 
   return axios
-    .put(API.UPDATE_CONFIRMATION(planId, confirmationId), { confirmed }, config)
+    .put(
+      API.UPDATE_CONFIRMATION(planId, confirmationId),
+      { confirmed, userId: user.id, isOwnSignature },
+      config
+    )
     .then(
       response => {
         return response.data

--- a/src/api/plan.js
+++ b/src/api/plan.js
@@ -52,8 +52,6 @@ const syncPlan = async planId => {
 
   if (isOnline) {
     if (localPlan && !localPlan.synced) {
-      console.log(localPlan)
-
       await savePlan(localPlan)
     }
 

--- a/src/api/plan.js
+++ b/src/api/plan.js
@@ -244,10 +244,12 @@ export const updateStatus = async ({ planId, note, statusId }) => {
 }
 
 export const updateConfirmation = async ({
+  user,
   planId,
   confirmationId,
   confirmed,
-  isMinorAmendment = false
+  isMinorAmendment = false,
+  isOwnSignature = true
 }) => {
   const config = {
     ...getAuthHeaderConfig(),
@@ -257,7 +259,7 @@ export const updateConfirmation = async ({
   }
   return axios.put(
     API.UPDATE_CONFIRMATION(planId, confirmationId),
-    { confirmed },
+    { confirmed, userId: user.id, isOwnSignature },
     config
   )
 }

--- a/src/components/loginPage/SignInBox.js
+++ b/src/components/loginPage/SignInBox.js
@@ -59,7 +59,6 @@ export class SignInBox extends Component {
       resetTimeoutForReAuth(reauthenticate)
       fetchUser().then(({ piaSeen }) => {
         if (!piaSeen) {
-          console.log('open pia modal')
           openPiaModal()
         }
       })

--- a/src/components/rangeUsePlanPage/SubmitAsMandatoryButton.js
+++ b/src/components/rangeUsePlanPage/SubmitAsMandatoryButton.js
@@ -56,8 +56,6 @@ const SubmitAsMandatoryButton = () => {
 
       await fetchPlan()
     } catch (e) {
-      console.log(e)
-
       errorToast(e.message)
     }
 

--- a/src/components/rangeUsePlanPage/basicInformation/index.js
+++ b/src/components/rangeUsePlanPage/basicInformation/index.js
@@ -1,5 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import useSWR from 'swr'
+import { CircularProgress } from '@material-ui/core'
+import * as API from '../../../constants/api'
 import { TextField, InfoTip } from '../../common'
 import * as strings from '../../../constants/strings'
 import {
@@ -7,7 +10,9 @@ import {
   capitalize,
   getUserFullName,
   getAgreementHolders,
-  getClientFullName
+  getClientFullName,
+  axios,
+  getAuthHeaderConfig
 } from '../../../utils'
 import PermissionsField from '../../common/PermissionsField'
 import { BASIC_INFORMATION } from '../../../constants/fields'
@@ -15,6 +20,12 @@ import DateInputField from '../../common/form/DateInputField'
 import moment from 'moment'
 import { useReferences } from '../../../providers/ReferencesProvider'
 import { REFERENCE_KEY } from '../../../constants/variables'
+
+const getAgentForClient = (client, clientAgreements) => {
+  const { agent } = clientAgreements.find(ca => ca.clientId === client.id)
+
+  return agent
+}
 
 const BasicInformation = ({ plan, agreement }) => {
   const zone = agreement && agreement.zone
@@ -39,6 +50,14 @@ const BasicInformation = ({ plan, agreement }) => {
     agreementExemptionStatus: aes,
     clients
   } = agreement || {}
+
+  const {
+    data: clientAgreements,
+    isValidating: isLoadingClientAgreements,
+    error: clientAgreementsError
+  } = useSWR(API.GET_CLIENT_AGREEMENTS(plan.id), key =>
+    axios.get(key, getAuthHeaderConfig()).then(res => res.data)
+  )
 
   const exemptionStatusName = aes && aes.description
   const { primaryAgreementHolder, otherAgreementHolders } = getAgreementHolders(
@@ -142,21 +161,44 @@ const BasicInformation = ({ plan, agreement }) => {
           />
         </div>
 
-        <div className="rup__plan-info rup__cell-6">
-          <div className="rup__divider" />
-          <div className="rup__info-title">Agreement Holders</div>
-          <TextField
-            label={strings.PRIMARY_AGREEMENT_HOLDER}
-            text={primaryAgreementHolderName}
-          />
-          {otherAgreementHolders.map(client => (
+        {isLoadingClientAgreements && !clientAgreements && <CircularProgress />}
+        {clientAgreementsError && (
+          <span>
+            Error fetching client agreements: {clientAgreementsError.message}
+          </span>
+        )}
+        {clientAgreements && (
+          <div className="rup__plan-info rup__cell-6">
+            <div className="rup__divider" />
+            <div className="rup__info-title">Agreement Holders</div>
             <TextField
-              key={client.id}
-              label={strings.OTHER_AGREEMENT_HOLDER}
-              text={getClientFullName(client)}
+              label={strings.PRIMARY_AGREEMENT_HOLDER}
+              text={`${primaryAgreementHolderName} ${
+                getAgentForClient(primaryAgreementHolder, clientAgreements)
+                  ? `- Agent: ${getUserFullName(
+                      getAgentForClient(
+                        primaryAgreementHolder,
+                        clientAgreements
+                      )
+                    )}`
+                  : ''
+              }`}
             />
-          ))}
-        </div>
+            {otherAgreementHolders.map(client => (
+              <TextField
+                key={client.id}
+                label={strings.OTHER_AGREEMENT_HOLDER}
+                text={`${getClientFullName(client)} ${
+                  getAgentForClient(client, clientAgreements)
+                    ? `- Agent: ${getUserFullName(
+                        getAgentForClient(client, clientAgreements)
+                      )}`
+                    : ''
+                }`}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/rangeUsePlanPage/basicInformation/index.js
+++ b/src/components/rangeUsePlanPage/basicInformation/index.js
@@ -20,6 +20,7 @@ import DateInputField from '../../common/form/DateInputField'
 import moment from 'moment'
 import { useReferences } from '../../../providers/ReferencesProvider'
 import { REFERENCE_KEY } from '../../../constants/variables'
+import { isUUID } from 'uuid-v4'
 
 const getAgentForClient = (client, clientAgreements) => {
   const { agent } = clientAgreements.find(ca => ca.clientId === client.id)
@@ -54,7 +55,7 @@ const BasicInformation = ({ plan, agreement }) => {
   const {
     data: clientAgreements,
     isValidating: isLoadingClientAgreements,
-    error: clientAgreementsError
+    error: errorFetchingClientAgreements
   } = useSWR(API.GET_CLIENT_AGREEMENTS(plan.id), key =>
     axios.get(key, getAuthHeaderConfig()).then(res => res.data)
   )
@@ -162,10 +163,25 @@ const BasicInformation = ({ plan, agreement }) => {
         </div>
 
         {isLoadingClientAgreements && !clientAgreements && <CircularProgress />}
-        {clientAgreementsError && (
-          <span>
-            Error fetching client agreements: {clientAgreementsError.message}
-          </span>
+        {!isUUID(plan.id) && errorFetchingClientAgreements && (
+          <span>Error: {errorFetchingClientAgreements.message}</span>
+        )}
+        {!clientAgreements && isUUID(plan.id) && (
+          <div className="rup__plan-info rup__cell-6">
+            <div className="rup__divider" />
+            <div className="rup__info-title">Agreement Holders</div>
+            <TextField
+              label={strings.PRIMARY_AGREEMENT_HOLDER}
+              text={primaryAgreementHolderName}
+            />
+            {otherAgreementHolders.map(client => (
+              <TextField
+                key={client.id}
+                label={strings.OTHER_AGREEMENT_HOLDER}
+                text={getClientFullName(client)}
+              />
+            ))}
+          </div>
         )}
         {clientAgreements && (
           <div className="rup__plan-info rup__cell-6">

--- a/src/components/rangeUsePlanPage/index.js
+++ b/src/components/rangeUsePlanPage/index.js
@@ -57,6 +57,7 @@ const Base = ({
   const {
     setCurrentPlanId,
     currentPlan,
+    clientAgreements,
     currentPlanId,
     fetchPlan,
     isFetchingPlan,
@@ -243,6 +244,7 @@ const Base = ({
                   references={references}
                   agreement={agreement}
                   plan={plan}
+                  clientAgreements={clientAgreements}
                   fetchPlan={fetchPlan}
                   user={user}
                   history={history}
@@ -255,6 +257,7 @@ const Base = ({
                   references={references}
                   agreement={agreement}
                   plan={plan}
+                  clientAgreements={clientAgreements}
                   fetchPlan={fetchPlan}
                   user={user}
                   history={history}

--- a/src/components/rangeUsePlanPage/notifications/AHSignaturesStatusModal.js
+++ b/src/components/rangeUsePlanPage/notifications/AHSignaturesStatusModal.js
@@ -4,7 +4,7 @@ import { Icon, Modal } from 'semantic-ui-react'
 import AHConfirmationList from '../pageForAH/confirmationTabs/AHConfirmationList'
 import { PrimaryButton } from '../../common'
 
-const AHSignaturesStatusModal = ({ plan, user }) => {
+const AHSignaturesStatusModal = ({ plan, user, clientAgreements }) => {
   const [isModalOpen, setModalOpen] = useState(false)
 
   const openModal = () => setModalOpen(true)
@@ -38,7 +38,12 @@ const AHSignaturesStatusModal = ({ plan, user }) => {
               There are still agreement holders who have not yet confirmed their
               confirmation choice.
             </span>
-            <AHConfirmationList user={user} clients={clients} plan={plan} />
+            <AHConfirmationList
+              user={user}
+              clients={clients}
+              plan={plan}
+              clientAgreements={clientAgreements}
+            />
             <span>
               This amendment will not be submitted until all agreement holders
               have confirmed and eSigned.

--- a/src/components/rangeUsePlanPage/pageForAH/confirmationTabs/AHConfirmationList.js
+++ b/src/components/rangeUsePlanPage/pageForAH/confirmationTabs/AHConfirmationList.js
@@ -6,9 +6,11 @@ import {
   findConfirmationWithClientId,
   formatDateFromServer,
   isClientCurrentUser,
-  getClientFullName
+  getClientFullName,
+  isAgent
 } from '../../../../utils'
 import { AWAITING_CONFIRMATION } from '../../../../constants/strings'
+import { getUserFullName } from '../../pdf/helper'
 
 class AHConfirmationList extends Component {
   static propTypes = {
@@ -18,6 +20,7 @@ class AHConfirmationList extends Component {
   }
 
   renderConfirmation = (client, confirmation, user) => {
+    const { clientAgreements } = this.props
     const { confirmed, updatedAt } = confirmation || {}
     const confirmationDate = confirmed
       ? formatDateFromServer(updatedAt)
@@ -29,12 +32,15 @@ class AHConfirmationList extends Component {
           <Icon name="user outline" />
           <span
             className={classnames('rup__confirmation__ah-list__cname', {
-              'rup__confirmation__ah-list__cname--bold': isClientCurrentUser(
-                client,
-                user
-              )
+              'rup__confirmation__ah-list__cname--bold':
+                isClientCurrentUser(client, user) ||
+                (isAgent(clientAgreements, user, client) &&
+                  confirmation.user.id === user.id)
             })}>
-            {getClientFullName(client)}
+            {getClientFullName(client)}{' '}
+            {confirmed &&
+              !confirmation.isOwnSignature &&
+              `(by ${getUserFullName(confirmation.user)})`}
           </span>
         </div>
         <div>{confirmationDate}</div>

--- a/src/components/rangeUsePlanPage/pageForAH/confirmationTabs/ConfirmChoiceTab.js
+++ b/src/components/rangeUsePlanPage/pageForAH/confirmationTabs/ConfirmChoiceTab.js
@@ -52,6 +52,7 @@ class ConfirmChoiceTab extends Component {
     const {
       user,
       clients,
+      clientAgreements,
       plan,
       currTabId,
       tab,
@@ -126,7 +127,12 @@ class ConfirmChoiceTab extends Component {
               />
             </Form.Field>
 
-            <AHConfirmationList user={user} clients={clients} plan={plan} />
+            <AHConfirmationList
+              user={user}
+              clients={clients}
+              plan={plan}
+              clientAgreements={clientAgreements}
+            />
 
             <Form.Checkbox
               label="I understand that this submission constitues a legal document and eSignature. This submission will be reviewed by the range staff before it is forwarded to the decision maker."

--- a/src/components/rangeUsePlanPage/pageForAH/index.js
+++ b/src/components/rangeUsePlanPage/pageForAH/index.js
@@ -174,7 +174,7 @@ class PageForAH extends Component {
 
   renderActionBtns = () => {
     const { isSavingAsDraft, isSubmitting, isCreatingAmendment } = this.state
-    const { openConfirmationModal, plan, user } = this.props
+    const { openConfirmationModal, plan, user, clientAgreements } = this.props
     const { confirmations, status } = plan
 
     return (
@@ -182,7 +182,12 @@ class PageForAH extends Component {
         permissions={{
           edit: utils.canUserEditThisPlan(plan, user),
           amend: utils.isStatusAmongApprovedStatuses(status),
-          confirm: utils.canUserSubmitConfirmation(status, user, confirmations),
+          confirm: utils.canUserSubmitConfirmation(
+            status,
+            user,
+            confirmations,
+            clientAgreements
+          ),
           submit: utils.canUserSubmitPlan(plan, user),
           discard: utils.canUserDiscardAmendment(plan, user),
           amendFromLegal: utils.canUserAmendFromLegal(plan, user)
@@ -217,6 +222,7 @@ class PageForAH extends Component {
 
     const {
       plan,
+      clientAgreements,
       user,
       agreement,
       references,
@@ -239,6 +245,7 @@ class PageForAH extends Component {
           onClose={this.closePlanSubmissionModal}
           plan={plan}
           clients={clients}
+          clientAgreements={clientAgreements}
           updateStatusAndContent={this.updateStatusAndContent}
           fetchPlan={fetchPlan}
         />
@@ -248,6 +255,7 @@ class PageForAH extends Component {
           onClose={this.closeAHSignatureModal}
           plan={plan}
           clients={clients}
+          clientAgreements={clientAgreements}
           updateStatusAndContent={this.updateStatusAndContent}
           fetchPlan={fetchPlan}
           onSuccess={() => fetchPlan()}
@@ -259,6 +267,7 @@ class PageForAH extends Component {
           onClose={this.closeAmendmentSubmissionModal}
           plan={plan}
           clients={clients}
+          clientAgreements={clientAgreements}
           updateStatusAndContent={this.updateStatusAndContent}
           fetchPlan={fetchPlan}
         />
@@ -290,6 +299,7 @@ class PageForAH extends Component {
           <Notifications
             plan={plan}
             user={user}
+            clientAgreements={clientAgreements}
             references={references}
             planStatusHistoryMap={planStatusHistoryMap}
           />

--- a/src/components/rangeUsePlanPage/pageForAH/submissionTabs/RequestSignaturesTab.js
+++ b/src/components/rangeUsePlanPage/pageForAH/submissionTabs/RequestSignaturesTab.js
@@ -41,20 +41,21 @@ class RequestSignaturesTab extends Component {
   }
 
   renderAgreementHolder = client => {
-    const { user } = this.props
+    const { user, clientAgreements } = this.props
+    const agencyAgreements = clientAgreements.filter(a => a.agentId === user.id)
+    const isAgent = !!agencyAgreements.find(ca => ca.clientId === client.id)
 
     return (
       <div key={client.id} className="rup__multi-tab__ah-list">
         <Icon name="user outline" />
         <span
           className={classnames('rup__multi-tab__ah-list__cname', {
-            'rup__multi-tab__ah-list__cname--bold': isClientCurrentUser(
-              client,
-              user
-            )
+            'rup__multi-tab__ah-list__cname--bold':
+              isClientCurrentUser(client, user) || isAgent
           })}>
           {getClientFullName(client)}
           {isClientCurrentUser(client, user) && ' (in progress)'}
+          {isAgent && ' (signing for as agent)'}
         </span>
       </div>
     )

--- a/src/components/rangeUsePlanPage/pageForAH/tabs/MandatoryTabsForMultipleAH.js
+++ b/src/components/rangeUsePlanPage/pageForAH/tabs/MandatoryTabsForMultipleAH.js
@@ -32,6 +32,7 @@ class MandatoryTabsForMultipleAH extends Component {
     const {
       user,
       clients,
+      clientAgreements,
       statusCode,
       isAgreed,
       isSubmitting,
@@ -144,6 +145,7 @@ class MandatoryTabsForMultipleAH extends Component {
           currTabId={currTabId}
           tab={tabsMap.requestSignatures}
           clients={clients}
+          clientAgreements={clientAgreements}
           user={user}
           isSubmitting={isSubmitting}
           handleTabChange={handleTabChange}

--- a/src/components/rangeUsePlanPage/pageForAH/tabs/MinorTabsForMultipleAH.js
+++ b/src/components/rangeUsePlanPage/pageForAH/tabs/MinorTabsForMultipleAH.js
@@ -25,6 +25,7 @@ class MinorTabsForMultipleAH extends Component {
     const {
       user,
       clients,
+      clientAgreements,
       isAgreed,
       isSubmitting,
       handleAgreeCheckBoxChange,
@@ -93,6 +94,7 @@ class MinorTabsForMultipleAH extends Component {
           currTabId={currTabId}
           tab={tabsMap.requestSignatures}
           clients={clients}
+          clientAgreements={clientAgreements}
           user={user}
           isSubmitting={isSubmitting}
           handleTabChange={handleTabChange}

--- a/src/components/rangeUsePlanPage/pageForAH/tabs/TabsForMultipleAH.js
+++ b/src/components/rangeUsePlanPage/pageForAH/tabs/TabsForMultipleAH.js
@@ -13,6 +13,7 @@ class TabsForMultipleAH extends Component {
   static propTypes = {
     user: PropTypes.shape({}).isRequired,
     clients: PropTypes.arrayOf(PropTypes.object).isRequired,
+    clientAgreements: PropTypes.array.isRequired,
     statusCode: PropTypes.string,
     isSubmitting: PropTypes.bool.isRequired,
     isAgreed: PropTypes.bool.isRequired,
@@ -50,7 +51,8 @@ class TabsForMultipleAH extends Component {
       handleNoteChange,
       onSubmitClicked,
       onClose,
-      user
+      user,
+      clientAgreements
     } = this.props
     const { currTabId } = this.state
     const tabsMap = {
@@ -166,6 +168,7 @@ class TabsForMultipleAH extends Component {
           currTabId={currTabId}
           tab={tabsMap.requestSignatures}
           clients={clients}
+          clientAgreements={clientAgreements}
           user={user}
           isSubmitting={isSubmitting}
           handleTabChange={this.handleTabChange}

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -212,6 +212,7 @@ class PageForStaff extends Component {
     const {
       agreement,
       user,
+      clientAgreements,
       references,
       plan,
       planStatusHistoryMap,
@@ -280,6 +281,7 @@ class PageForStaff extends Component {
           <Notifications
             plan={plan}
             user={user}
+            clientAgreements={clientAgreements}
             references={references}
             planStatusHistoryMap={planStatusHistoryMap}
             planTypeDescription={planTypeDescription}

--- a/src/components/rangeUsePlanPage/pdf/helper.js
+++ b/src/components/rangeUsePlanPage/pdf/helper.js
@@ -10,9 +10,6 @@ import {
 import { NOT_PROVIDED } from '../../../constants/strings'
 
 export const getPDFStatus = status => {
-  console.log(PDF_DRAFT_STATUSES)
-  console.log(PDF_DRAFT_STATUSES.includes(status.code))
-
   if (PDF_DRAFT_STATUSES.includes(status.code)) {
     return 'DRAFT'
   } else if (PDF_IN_EFFECT_STATUSES.includes(status.code)) {

--- a/src/components/rangeUsePlanPage/pdf/pdf/FrontPage.js
+++ b/src/components/rangeUsePlanPage/pdf/pdf/FrontPage.js
@@ -4,6 +4,7 @@ import { IMAGE_SRC } from '../../../../constants/variables'
 import Footer from './Footer'
 import moment from 'moment'
 import { config } from './common/config'
+import { getUserFullName } from '../helper'
 
 const styles = StyleSheet.create({
   page: {
@@ -78,6 +79,11 @@ const FrontPage = ({ plan }) => (
             {confirmation && confirmation.confirmed
               ? moment(confirmation.updatedAt).format('MMMM DD, YYYY')
               : 'Awaiting Signature'}
+            {confirmation &&
+              confirmation.confirmed &&
+              !confirmation.isOwnSignature && (
+                <Text> by {getUserFullName(confirmation.user)}</Text>
+              )}
           </Text>
         )
       })}

--- a/src/components/selectRangeUsePlanPage/PlanTableRow.js
+++ b/src/components/selectRangeUsePlanPage/PlanTableRow.js
@@ -18,7 +18,6 @@ const PlanTableRow = ({ plan }) => {
   const references = useReferences()
   const { page } = useParams()
   const location = useLocation()
-  // console.log(loc)
 
   const amendmentTypes = references[REFERENCE_KEY.AMENDMENT_TYPE]
   if (!amendmentTypes) return <Loader />

--- a/src/components/selectRangeUsePlanPage/ZoneSelect.js
+++ b/src/components/selectRangeUsePlanPage/ZoneSelect.js
@@ -76,7 +76,6 @@ export default function ZoneSelect({
     `${API.GET_USERS}/?orderCId=desc&excludeBy=username&exclude=bceid`,
     key => axios.get(key, getAuthHeaderConfig()).then(res => res.data)
   )
-  console.log(users)
 
   useEffect(() => {
     if (userZones) {

--- a/src/components/selectRangeUsePlanPage/index.js
+++ b/src/components/selectRangeUsePlanPage/index.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import useSWR from 'swr'
 import * as API from '../../constants/api'
-import { axios, getAuthHeaderConfig } from '../../utils'
+import { axios, getAuthHeaderConfig, isUserRangeOfficer } from '../../utils'
 import Error from './Error'
 import { makeStyles } from '@material-ui/core/styles'
 import ZoneSelect from './ZoneSelect'
@@ -85,13 +85,15 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
             placeholder={AGREEMENT_SEARCH_PLACEHOLDER}
             initialValue={term}
           />
-          <ZoneSelect
-            zones={zones}
-            userZones={userZones}
-            unassignedZones={unassignedZones}
-            zoneUsers={zoneUsers}
-            setSearchSelectedZones={setSearchSelectedZones}
-          />
+          {isUserRangeOfficer(user) && (
+            <ZoneSelect
+              zones={zones}
+              userZones={userZones}
+              unassignedZones={unassignedZones}
+              zoneUsers={zoneUsers}
+              setSearchSelectedZones={setSearchSelectedZones}
+            />
+          )}
         </div>
 
         {error ? (

--- a/src/providers/PlanProvider.js
+++ b/src/providers/PlanProvider.js
@@ -6,7 +6,9 @@ import * as reduxSchema from '../actionCreators/schema'
 import schema from '../components/rangeUsePlanPage/schema'
 import { getNetworkStatus } from '../utils/helper/network'
 import { connect } from 'react-redux'
-import { appendUsage } from '../utils'
+import { appendUsage, axios, getAuthHeaderConfig } from '../utils'
+import { GET_CLIENT_AGREEMENTS } from '../constants/api'
+import { isUUID } from 'uuid-v4'
 
 /**
  * @typedef {Object} PlanContext
@@ -37,6 +39,7 @@ export const PlanProvider = ({ children, storePlan }) => {
   const [isSavingPlan, setSavingPlan] = useState(false)
   const [errorFetchingPlan, setErrorFetchingPlan] = useState(null)
   const [errorSavingPlan, setErrorSavingPlan] = useState(null)
+  const [clientAgreements, setClientAgreements] = useState(null)
 
   const fetchPlan = async (planId = currentPlanId, hard = false) => {
     setFetchingPlan(true)
@@ -48,6 +51,14 @@ export const PlanProvider = ({ children, storePlan }) => {
     try {
       const plan = await API.getPlan(planId)
       setCurrentPlan(schema.cast(appendUsage(plan)))
+
+      if (!isUUID(plan.id)) {
+        const { data: clientAgreements } = await axios.get(
+          GET_CLIENT_AGREEMENTS(plan.id),
+          getAuthHeaderConfig()
+        )
+        setClientAgreements(clientAgreements)
+      }
 
       // TODO: remove redux
       const isOnline = await getNetworkStatus()
@@ -90,6 +101,7 @@ export const PlanProvider = ({ children, storePlan }) => {
       value={{
         setCurrentPlanId,
         currentPlan,
+        clientAgreements,
         isFetchingPlan,
         isSavingPlan,
         errorFetchingPlan,

--- a/src/utils/helper/client.js
+++ b/src/utils/helper/client.js
@@ -28,6 +28,15 @@ export const isClientCurrentUser = (client, user) => {
   return false
 }
 
+export const isAgent = (clientAgreements, user, client) => {
+  if (!user || !client || !clientAgreements) return false
+
+  const agencyAgreements = clientAgreements.filter(a => a.agentId === user.id)
+  const isAgent = !!agencyAgreements.find(ca => ca.clientId === client.id)
+
+  return isAgent
+}
+
 export const findConfirmationWithClientId = (clientId, confirmations) => {
   if (clientId && confirmations) {
     return confirmations.find(
@@ -52,6 +61,24 @@ export const findConfirmationWithUser = (user, confirmations) => {
   }
 
   return linkedConfirmations[0]
+}
+
+export const findConfirmationsWithUser = (
+  user,
+  confirmations,
+  clientAgreements
+) => {
+  const { clients = [] } = user
+
+  const agencyAgreements = clientAgreements.filter(ca => ca.agentId === user.id)
+
+  const linkedConfirmations = confirmations.filter(
+    confirmation =>
+      clients.some(client => client.id === confirmation.clientId) ||
+      agencyAgreements.some(a => a.clientId === confirmation.clientId)
+  )
+
+  return linkedConfirmations
 }
 
 export const getClientFullName = contact => {

--- a/src/utils/helper/plan.js
+++ b/src/utils/helper/plan.js
@@ -10,7 +10,7 @@ import {
 } from '../../constants/variables'
 import { isAmendment } from './amendment'
 import { isUserAgreementHolder, isUserStaff } from './user'
-import { findConfirmationWithUser } from './client'
+import { findConfirmationsWithUser } from './client'
 
 const getAmendmentTypeDescription = (amendmentTypeId, amendmentTypes) => {
   if (amendmentTypeId && amendmentTypes) {
@@ -171,10 +171,19 @@ export const canUserSubmitPlan = (plan = {}, user = {}) => {
   }
 }
 
-export const canUserSubmitConfirmation = (status, user, confirmations = []) => {
+export const canUserSubmitConfirmation = (
+  status,
+  user,
+  confirmations = [],
+  clientAgreements = []
+) => {
   if (isStatusAwaitingConfirmation(status) && user) {
     const isConfirmed =
-      findConfirmationWithUser(user, confirmations)?.confirmed ?? false
+      findConfirmationsWithUser(
+        user,
+        confirmations,
+        clientAgreements ?? []
+      )?.every(ca => ca.confirmed) ?? false
 
     // users who haven't confirmed yet can submit the confirmation
     return !isConfirmed


### PR DESCRIPTION
Whenever you sign/submit/create an amendment, all signatures that you are allowed to sign (ie. the AHs you are an agent for) will be updated accordingly. This means you can sign for all AHs you have agency for in one go.

Relates to #633

Depends on https://github.com/bcgov/range-api/pull/236