### PR TITLE
Fix RUP permissions for plans outside zone

### DIFF
--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -157,19 +157,18 @@ class PageForStaff extends Component {
   renderActionBtns = () => {
     const { isSavingAsDraft, isSubmitting } = this.state
     const { openConfirmationModal, plan, user } = this.props
-    const { status } = plan
 
     return (
       <ActionBtns
         permissions={{
           edit: utils.canUserEditThisPlan(plan, user),
           submit: utils.canUserSubmitPlan(plan, user),
-          amend: utils.isStatusAmongApprovedStatuses(status),
+          amend: utils.canUserAmendPlan(plan, user),
           discard: utils.canUserDiscardAmendment(plan, user),
-          updateStatus: true,
+          updateStatus: utils.doesStaffOwnPlan(plan, user),
           submitAsMandatory: utils.canUserSubmitAsMandatory(plan, user),
           amendFromLegal: utils.canUserAmendFromLegal(plan, user),
-          manageAgents: true
+          manageAgents: utils.doesStaffOwnPlan(plan, user)
         }}
         isSubmitting={isSubmitting}
         isSavingAsDraft={isSavingAsDraft}

--- a/src/components/selectRangeUsePlanPage/SortableAgreementTable.js
+++ b/src/components/selectRangeUsePlanPage/SortableAgreementTable.js
@@ -161,6 +161,10 @@ const useStyles = makeStyles(theme => ({
 function PlanRow({ agreement, location, user, currentPage }) {
   const classes = useStyles()
   const [open, setOpen] = useState(false)
+  const canEdit = canUserEditThisPlan(
+    { ...agreement.plans[0], agreement },
+    user
+  )
   return (
     <>
       <TableRow className={classes.root} hover tabIndex={-1} key={agreement.id}>
@@ -225,16 +229,8 @@ function PlanRow({ agreement, location, user, currentPage }) {
                   prevSearch: location.search
                 }
               }}
-              endIcon={
-                canUserEditThisPlan(agreement.plans[0], user) ? (
-                  <EditIcon />
-                ) : (
-                  <ViewIcon />
-                )
-              }>
-              {canUserEditThisPlan(agreement.plans[0], user)
-                ? 'Edit'
-                : strings.VIEW}
+              endIcon={canEdit ? <EditIcon /> : <ViewIcon />}>
+              {canEdit ? 'Edit' : strings.VIEW}
             </Button>
           )}
         </TableCell>

--- a/src/components/selectRangeUsePlanPage/ZoneSelect.js
+++ b/src/components/selectRangeUsePlanPage/ZoneSelect.js
@@ -9,6 +9,7 @@ import Select from '@material-ui/core/Select'
 import Checkbox from '@material-ui/core/Checkbox'
 import { getUserFullName, axios, getAuthHeaderConfig } from '../../utils'
 import * as API from '../../constants/api'
+import { useQueryParam, DelimitedNumericArrayParam } from 'use-query-params'
 
 const useStyles = makeStyles(theme => ({
   formControl: {
@@ -69,7 +70,10 @@ export default function ZoneSelect({
   setSearchSelectedZones
 }) {
   const classes = useStyles()
-  const [selectedZones, setSelectedZones] = useState([])
+  const [selectedZones = [], setSelectedZones] = useQueryParam(
+    'selectedZones',
+    DelimitedNumericArrayParam
+  )
   const [zoneMap, setZoneMap] = useState()
 
   const { data: users, error, isValidating } = useSWR(
@@ -78,10 +82,12 @@ export default function ZoneSelect({
   )
 
   useEffect(() => {
-    if (userZones) {
+    if (userZones && selectedZones.length === 0) {
       const initialSelectedZones = userZones.map(zone => zone.id)
       setSelectedZones(initialSelectedZones)
     }
+
+    setSearchSelectedZones(selectedZones)
   }, [])
 
   useEffect(() => {
@@ -104,7 +110,7 @@ export default function ZoneSelect({
     setSearchSelectedZones(selectedZones)
   }
 
-  if (isValidating && !users) {
+  if ((isValidating && !users) || !zoneMap) {
     return <span>Loading zones</span>
   }
 

--- a/src/utils/helper/plan.js
+++ b/src/utils/helper/plan.js
@@ -161,9 +161,10 @@ export const canUserSubmitPlan = (plan = {}, user = {}) => {
 
   if (user.roles.includes('myra_range_officer')) {
     return (
-      status.code === PLAN_STATUS.STAFF_DRAFT ||
-      status.code === PLAN_STATUS.MANDATORY_AMENDMENT_STAFF ||
-      status.code === PLAN_STATUS.SUBMITTED_AS_MANDATORY
+      doesStaffOwnPlan(plan, user) &&
+      (status.code === PLAN_STATUS.STAFF_DRAFT ||
+        status.code === PLAN_STATUS.MANDATORY_AMENDMENT_STAFF ||
+        status.code === PLAN_STATUS.SUBMITTED_AS_MANDATORY)
     )
   }
   if (user.roles.includes('myra_client')) {
@@ -191,6 +192,17 @@ export const canUserSubmitConfirmation = (
   return false
 }
 
+export const doesStaffOwnPlan = (plan = {}, user = {}) => {
+  return plan?.agreement?.zone?.userId === user.id
+}
+
+export const canUserAmendPlan = (plan = {}, user = {}) => {
+  return (
+    isStatusAmongApprovedStatuses(plan.status) &&
+    doesStaffOwnPlan(plan.agreement, user)
+  )
+}
+
 export const canUserEditThisPlan = (plan = {}, user = {}) => {
   const { status } = plan
 
@@ -200,7 +212,9 @@ export const canUserEditThisPlan = (plan = {}, user = {}) => {
     isStatusMandatoryAmendmentStaff(status) ||
     isStatusSubmittedAsMandatory(status)
   ) {
-    return user.roles.includes('myra_range_officer')
+    return (
+      user.roles.includes('myra_range_officer') && doesStaffOwnPlan(plan, user)
+    )
   }
 
   if (
@@ -221,7 +235,10 @@ export const canUserDiscardAmendment = (plan, user) => {
   if (!user || !plan) return false
 
   if (user.roles.includes(USER_ROLE.RANGE_OFFICER)) {
-    return isStatusMandatoryAmendmentStaff(plan.status)
+    return (
+      doesStaffOwnPlan(plan, user) &&
+      isStatusMandatoryAmendmentStaff(plan.status)
+    )
   }
 
   if (user.roles.includes(USER_ROLE.AGREEMENT_HOLDER)) {
@@ -234,14 +251,17 @@ export const canUserDiscardAmendment = (plan, user) => {
 export const canUserAmendFromLegal = (plan, user) => {
   if (!user || !plan) return false
 
-  return isStatusWronglyMakeWE(plan.status) || isStatusNotApproved(plan.status)
+  return (
+    doesStaffOwnPlan(plan, user) &&
+    (isStatusWronglyMakeWE(plan.status) || isStatusNotApproved(plan.status))
+  )
 }
 
 export const canUserSubmitAsMandatory = (plan, user) => {
   if (!user || !plan) return false
 
   if (user.roles.includes(USER_ROLE.RANGE_OFFICER)) {
-    return isStatusStandsReview(plan.status)
+    return doesStaffOwnPlan(plan, user) && isStatusStandsReview(plan.status)
   }
 
   return false


### PR DESCRIPTION
I've change the permissions so that range officers accessing plans outside of their assigned zone can not make any modifications to those plans.

I've also stored the selected zones the users if filtering by in the URL's query params, so the selection should stay across refreshes and when the user navigates back using browser history.

Relates to #563