### PR TITLE
Show username in Manage clients

### DIFF
--- a/src/components/manageClientPage/index.js
+++ b/src/components/manageClientPage/index.js
@@ -79,22 +79,23 @@ const ManageClientPage = () => {
                     variant="outlined"
                   />
                 )}
-                renderOption={option => {
-                  return (
-                    <Grid container alignItems="center">
-                      <Grid item>
-                        <PersonIcon className={classes.icon} />
-                      </Grid>
-                      <Grid item xs>
-                        {getUserFullName(option)}
-
-                        <Typography variant="body2" color="textSecondary">
-                          {option.email}
-                        </Typography>
-                      </Grid>
+                renderOption={option => (
+                  <Grid container alignItems="center">
+                    <Grid item>
+                      <PersonIcon className={classes.icon} />
                     </Grid>
-                  )
-                }}
+                    <Grid item xs>
+                      {getUserFullName(option)}
+
+                      <Typography variant="body2" color="textSecondary">
+                        {option.email}
+                      </Typography>
+                      <Typography variant="body2" color="textSecondary">
+                        {option.username}
+                      </Typography>
+                    </Grid>
+                  </Grid>
+                )}
               />
             </>
           )}

--- a/src/components/manageClientPage/index.js
+++ b/src/components/manageClientPage/index.js
@@ -71,7 +71,7 @@ const ManageClientPage = () => {
                 }}
                 getOptionLabel={option => getUserFullName(option)}
                 getOptionSelected={option => option.id === user.id}
-                style={{ width: 300 }}
+                style={{ width: 400 }}
                 renderInput={params => (
                   <TextField
                     {...params}


### PR DESCRIPTION
Sometimes, two or more users will use the same given name and email address which makes it difficult to diffrenciate the two users in the Manage Clients drop down. 

The dropdown now includes the username (or bceid) depending on which they use to log in. 

![image](https://user-images.githubusercontent.com/30703259/88415260-079f7a00-cd93-11ea-8ac5-a268dbeef88b.png)
