### PR TITLE
Fix attachments

### DIFF
--- a/src/components/rangeUsePlanPage/ContentsContainer.js
+++ b/src/components/rangeUsePlanPage/ContentsContainer.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { withRouter } from 'react-router-dom'
 import { ELEMENT_ID, IMAGE_SRC } from '../../constants/variables'
 import * as strings from '../../constants/strings'
+import { isUUID } from 'uuid-v4'
 
 class ContentsContainer extends Component {
   static propTypes = {
@@ -20,7 +21,7 @@ class ContentsContainer extends Component {
   }
 
   render() {
-    const { children } = this.props
+    const { children, plan } = this.props
 
     return (
       <div className="rup__contents__container">
@@ -88,15 +89,17 @@ class ContentsContainer extends Component {
             <img src={IMAGE_SRC.MANAGEMENT_ICON} alt="icon" />
             <span>{strings.MANAGEMENT_CONSIDERATIONS}</span>
           </Link>
-          <Link
-            offset={-100}
-            spy={true}
-            to={ELEMENT_ID.ATTACHMENTS}
-            className="rup__contents__tab"
-            activeClass="rup__contents__tab--active">
-            <img src={IMAGE_SRC.ATTACHMENTS} alt="icon" />
-            <span>{strings.ATTACHMENTS}</span>
-          </Link>
+          {!isUUID(plan.id) && (
+            <Link
+              offset={-100}
+              spy={true}
+              to={ELEMENT_ID.ATTACHMENTS}
+              className="rup__contents__tab"
+              activeClass="rup__contents__tab--active">
+              <img src={IMAGE_SRC.ATTACHMENTS} alt="icon" />
+              <span>{strings.ATTACHMENTS}</span>
+            </Link>
+          )}
         </div>
         <div className="rup__contents">{children.map(this.renderChild)}</div>
       </div>

--- a/src/components/rangeUsePlanPage/PlanForm.js
+++ b/src/components/rangeUsePlanPage/PlanForm.js
@@ -12,6 +12,7 @@ import MinisterIssues from './ministerIssues'
 import AdditionalRequirements from './additionalRequirements'
 import { Attachments, AttachmentsHeader } from './attachments'
 import EditableProvider from '../../providers/EditableProvider'
+import { isUUID } from 'uuid-v4'
 
 const PlanForm = ({ plan, isEditable = true }) => {
   return (
@@ -50,27 +51,31 @@ const PlanForm = ({ plan, isEditable = true }) => {
           managementConsiderations={plan.managementConsiderations}
         />
       </Element>
-      <Element name={ELEMENT_ID.ATTACHMENTS}>
-        <AttachmentsHeader />
-        <Attachments
-          planId={plan.id}
-          attachments={plan.files}
-          propertyName="decisionAttachments"
-          label="Decision Material"
-        />
-        <Attachments
-          planId={plan.id}
-          attachments={plan.files}
-          propertyName="mapAttachments"
-          label="Map"
-        />
-        <Attachments
-          planId={plan.id}
-          attachments={plan.files}
-          propertyName="otherAttachments"
-          label="Other"
-        />
-      </Element>
+      {!isUUID(plan.id) && (
+        <>
+          <Element name={ELEMENT_ID.ATTACHMENTS}>
+            <AttachmentsHeader />
+            <Attachments
+              planId={plan.id}
+              attachments={plan.files}
+              propertyName="decisionAttachments"
+              label="Decision Material"
+            />
+            <Attachments
+              planId={plan.id}
+              attachments={plan.files}
+              propertyName="mapAttachments"
+              label="Map"
+            />
+            <Attachments
+              planId={plan.id}
+              attachments={plan.files}
+              propertyName="otherAttachments"
+              label="Other"
+            />
+          </Element>
+        </>
+      )}
     </EditableProvider>
   )
 }

--- a/src/components/rangeUsePlanPage/attachments/AttachmentRow.js
+++ b/src/components/rangeUsePlanPage/attachments/AttachmentRow.js
@@ -12,6 +12,7 @@ import { Dropdown } from 'formik-semantic-ui'
 import { TextField } from '../../common'
 import { CircularProgress } from '@material-ui/core'
 import { GET_SIGNED_DOWNLOAD_URL } from '../../../constants/api'
+import { isUUID } from 'uuid-v4'
 
 const options = [
   {
@@ -88,7 +89,7 @@ const AttachmentRow = ({ attachment, index, onDelete, error }) => {
         {attachment.error && (
           <span>Error uploading file: {attachment.error.message}</span>
         )}
-        {attachment.url && !isDownloading && (
+        {attachment.url && !isUUID(attachment.id) && !isDownloading && (
           <div>
             <button onClick={handleDownload}>Download</button>
             {errorDownloading && (

--- a/src/components/rangeUsePlanPage/attachments/AttachmentRow.js
+++ b/src/components/rangeUsePlanPage/attachments/AttachmentRow.js
@@ -43,7 +43,17 @@ const AttachmentRow = ({ attachment, index, onDelete, error }) => {
         GET_SIGNED_DOWNLOAD_URL(attachment.id),
         getAuthHeaderConfig()
       )
-      window.open(res.data.url)
+      const fileRes = await axios.get(res.data.url, {
+        responseType: 'blob'
+      })
+
+      const url = window.URL.createObjectURL(fileRes.data)
+      const link = document.createElement('a')
+      link.href = url
+      link.setAttribute('download', attachment.name)
+      document.body.appendChild(link)
+      link.click()
+      link.parentNode.removeChild(link)
     } catch (e) {
       setErrorDownloading(e)
     }

--- a/src/components/rangeUsePlanPage/attachments/index.js
+++ b/src/components/rangeUsePlanPage/attachments/index.js
@@ -29,9 +29,12 @@ const Attachments = ({
     const fieldName = `files.${index}`
     try {
       const signedUrl = await getSignedUploadUrl(file.name)
-      const formData = new FormData()
-      formData.append(file.name, file)
-      await axios.put(signedUrl, formData)
+
+      await axios.put(signedUrl, file, {
+        headers: {
+          'Content-Type': file.type
+        }
+      })
 
       formik.setFieldValue(`${fieldName}.url`, file.name)
     } catch (e) {

--- a/src/components/rangeUsePlanPage/pageForStaff/index.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/index.js
@@ -280,7 +280,7 @@ class PageForStaff extends Component {
           </div>
         </StickyHeader>
 
-        <ContentsContainer>
+        <ContentsContainer plan={plan}>
           <Notifications
             plan={plan}
             user={user}


### PR DESCRIPTION
Fixes a couple of bugs with file attachments:

- [x] File contents don't include form metadata anymore, as this was corrupting the files
- [x] Disable file downloads when the plan isn't saved, since the backend isn't aware of the files yet and can't provide a pre-signed download URL
- [x] Hide attachments section for new, unsaved plans, since there are no records in the DB yet.
- [x] Fix download behaviour so files don't get opened in new tab