### PR TITLE
Add IDs to plan sections

### DIFF
--- a/src/components/rangeUsePlanPage/PlanForm.js
+++ b/src/components/rangeUsePlanPage/PlanForm.js
@@ -23,12 +23,14 @@ const PlanForm = ({ plan, isEditable = true }) => {
   return (
     <EditableProvider editable={isEditable}>
       {plan?.conditions !== '' && (
-        <Element name={ELEMENT_ID.CONDITIONS}>
+        <Element name={ELEMENT_ID.CONDITIONS} id={ELEMENT_ID.CONDITIONS}>
           <Conditions plan={plan} agreement={plan.agreement} />
         </Element>
       )}
 
-      <Element name={ELEMENT_ID.BASIC_INFORMATION}>
+      <Element
+        name={ELEMENT_ID.BASIC_INFORMATION}
+        id={ELEMENT_ID.BASIC_INFORMATION}>
         <BasicInformation plan={plan} agreement={plan.agreement} />
       </Element>
       <Element name={ELEMENT_ID.PASTURES} id={ELEMENT_ID.PASTURES}>
@@ -42,21 +44,29 @@ const PlanForm = ({ plan, isEditable = true }) => {
         id={ELEMENT_ID.GRAZING_SCHEDULE}>
         <GrazingSchedules plan={plan} />
       </Element>
-      <Element name={ELEMENT_ID.MINISTER_ISSUES}>
+      <Element
+        name={ELEMENT_ID.MINISTER_ISSUES}
+        id={ELEMENT_ID.MINISTER_ISSUES}>
         <MinisterIssues issues={plan.ministerIssues} />
       </Element>
-      <Element name={ELEMENT_ID.INVASIVE_PLANT_CHECKLIST}>
+      <Element
+        name={ELEMENT_ID.INVASIVE_PLANT_CHECKLIST}
+        id={ELEMENT_ID.INVASIVE_PLANT_CHECKLIST}>
         <InvasivePlantChecklist
           namespace="invasivePlantChecklist"
           invasivePlantChecklist={plan.invasivePlantChecklist}
         />
       </Element>
-      <Element name={ELEMENT_ID.ADDITIONAL_REQUIREMENTS}>
+      <Element
+        name={ELEMENT_ID.ADDITIONAL_REQUIREMENTS}
+        id={ELEMENT_ID.ADDITIONAL_REQUIREMENTS}>
         <AdditionalRequirements
           additionalRequirements={plan.additionalRequirements}
         />
       </Element>
-      <Element name={ELEMENT_ID.MANAGEMENT_CONSIDERATIONS}>
+      <Element
+        name={ELEMENT_ID.MANAGEMENT_CONSIDERATIONS}
+        id={ELEMENT_ID.MANAGEMENT_CONSIDERATIONS}>
         <ManagementConsiderations
           planId={plan.id}
           managementConsiderations={plan.managementConsiderations}
@@ -64,7 +74,7 @@ const PlanForm = ({ plan, isEditable = true }) => {
       </Element>
       {!isUUID(plan.id) && (
         <EditableProvider editable={canUserAddAttachments(plan, user)}>
-          <Element name={ELEMENT_ID.ATTACHMENTS}>
+          <Element name={ELEMENT_ID.ATTACHMENTS} id={ELEMENT_ID.ATTACHMENTS}>
             <AttachmentsHeader />
             <Attachments
               planId={plan.id}


### PR DESCRIPTION
Fixes a bug where certain sections couldn't be scrolled to if a validation error was encountered, causing an error.

Relates to #896, #895