### PR TITLE
Fix permissions for conditions fields

### DIFF
--- a/src/components/rangeUsePlanPage/conditions/index.js
+++ b/src/components/rangeUsePlanPage/conditions/index.js
@@ -6,6 +6,8 @@ import * as strings from '../../../constants/strings'
 import PermissionsField from '../../common/PermissionsField'
 import { TextArea } from 'formik-semantic-ui'
 import { useUser } from '../../../providers/UserProvider'
+import EditableProvider from '../../../providers/EditableProvider'
+import { isStatusSubmittedForFD } from '../../../utils'
 
 const Conditions = ({ plan }) => {
   const user = useUser()
@@ -58,18 +60,20 @@ const Conditions = ({ plan }) => {
                 />
               </div>
             </div>
-            <PermissionsField
-              permission={CONDITIONS.PROPOSED_CONDITIONS}
-              name="proposedConditions"
-              component={TextArea}
-              displayValue={
-                proposedConditions !== '' && proposedConditions !== null
-                  ? '\n' + proposedConditions
-                  : '\nNo conditions'
-              }
-              fieldProps={{ required: false }}
-              fast
-            />
+            <EditableProvider editable={isStatusSubmittedForFD(plan?.status)}>
+              <PermissionsField
+                permission={CONDITIONS.PROPOSED_CONDITIONS}
+                name="proposedConditions"
+                component={TextArea}
+                displayValue={
+                  proposedConditions !== '' && proposedConditions !== null
+                    ? '\n' + proposedConditions
+                    : '\nNo conditions'
+                }
+                fieldProps={{ required: false }}
+                fast
+              />
+            </EditableProvider>
           </div>
         )}
       </div>

--- a/src/constants/permissions.js
+++ b/src/constants/permissions.js
@@ -93,7 +93,7 @@ const permissions = {
     ATTACHMENTS.VIEWABLE_BY,
     ATTACHMENTS.DELETE,
     ATTACHMENTS.ADD,
-    CONDITIONS.RANGE_OFFICER_CONDITIONS
+    CONDITIONS.PROPOSED_CONDITIONS
   ],
   myra_client: [
     SCHEDULE.PASTURE,
@@ -116,7 +116,7 @@ const permissions = {
     MANAGEMENT_CONSIDERATIONS.ADD
   ],
   myra_admin: [],
-  myra_decision_maker: [CONDITIONS.DECISION_MAKER_CONDITIONS]
+  myra_decision_maker: [CONDITIONS.CONDITIONS]
 }
 
 export default permissions


### PR DESCRIPTION
Allow Range Officers and Decision Makers to edit their respective conditions fields in the correct statuses.

Relates to #855 
