### PR TITLE
DB Roles and Read only update

### DIFF
--- a/src/api/plan.js
+++ b/src/api/plan.js
@@ -3,6 +3,7 @@ import {
   axios,
   getAuthHeaderConfig,
   findStatusWithCode,
+<<<<<<< Updated upstream
   isUserRangeOfficer,
   canUserAddAttachments,
 } from '../utils';
@@ -10,6 +11,15 @@ import * as API from '../constants/api';
 import RUPSchema from '../components/rangeUsePlanPage/schema';
 import { getNetworkStatus } from '../utils/helper/network';
 import { deleteFromQueue } from './delete';
+=======
+  isUserAgrologist,
+  canUserAddAttachments
+} from '../utils'
+import * as API from '../constants/api'
+import RUPSchema from '../components/rangeUsePlanPage/schema'
+import { getNetworkStatus } from '../utils/helper/network'
+import { deleteFromQueue } from './delete'
+>>>>>>> Stashed changes
 import {
   saveGrazingSchedules,
   saveInvasivePlantChecklist,
@@ -109,6 +119,7 @@ export const savePlan = async (plan, user = {}) => {
     }),
   );
 
+<<<<<<< Updated upstream
   await saveGrazingSchedules(planId, grazingSchedules, newPastures);
   await saveInvasivePlantChecklist(planId, invasivePlantChecklist);
   await saveManagementConsiderations(planId, managementConsiderations);
@@ -116,6 +127,15 @@ export const savePlan = async (plan, user = {}) => {
   await saveAdditionalRequirements(planId, additionalRequirements);
   if (isUserRangeOfficer(user) && canUserAddAttachments(plan, user)) {
     await saveAttachments(planId, files);
+=======
+  await saveGrazingSchedules(planId, grazingSchedules, newPastures)
+  await saveInvasivePlantChecklist(planId, invasivePlantChecklist)
+  await saveManagementConsiderations(planId, managementConsiderations)
+  await saveMinisterIssues(planId, ministerIssues, newPastures)
+  await saveAdditionalRequirements(planId, additionalRequirements)
+  if (isUserAgrologist(user) && canUserAddAttachments(plan, user)) {
+    await saveAttachments(planId, files)
+>>>>>>> Stashed changes
   }
 
   return planId;

--- a/src/api/plan.js
+++ b/src/api/plan.js
@@ -3,15 +3,6 @@ import {
   axios,
   getAuthHeaderConfig,
   findStatusWithCode,
-<<<<<<< Updated upstream
-  isUserRangeOfficer,
-  canUserAddAttachments,
-} from '../utils';
-import * as API from '../constants/api';
-import RUPSchema from '../components/rangeUsePlanPage/schema';
-import { getNetworkStatus } from '../utils/helper/network';
-import { deleteFromQueue } from './delete';
-=======
   isUserAgrologist,
   canUserAddAttachments
 } from '../utils'
@@ -19,7 +10,6 @@ import * as API from '../constants/api'
 import RUPSchema from '../components/rangeUsePlanPage/schema'
 import { getNetworkStatus } from '../utils/helper/network'
 import { deleteFromQueue } from './delete'
->>>>>>> Stashed changes
 import {
   saveGrazingSchedules,
   saveInvasivePlantChecklist,
@@ -119,15 +109,6 @@ export const savePlan = async (plan, user = {}) => {
     }),
   );
 
-<<<<<<< Updated upstream
-  await saveGrazingSchedules(planId, grazingSchedules, newPastures);
-  await saveInvasivePlantChecklist(planId, invasivePlantChecklist);
-  await saveManagementConsiderations(planId, managementConsiderations);
-  await saveMinisterIssues(planId, ministerIssues, newPastures);
-  await saveAdditionalRequirements(planId, additionalRequirements);
-  if (isUserRangeOfficer(user) && canUserAddAttachments(plan, user)) {
-    await saveAttachments(planId, files);
-=======
   await saveGrazingSchedules(planId, grazingSchedules, newPastures)
   await saveInvasivePlantChecklist(planId, invasivePlantChecklist)
   await saveManagementConsiderations(planId, managementConsiderations)
@@ -135,7 +116,6 @@ export const savePlan = async (plan, user = {}) => {
   await saveAdditionalRequirements(planId, additionalRequirements)
   if (isUserAgrologist(user) && canUserAddAttachments(plan, user)) {
     await saveAttachments(planId, files)
->>>>>>> Stashed changes
   }
 
   return planId;

--- a/src/api/user.js
+++ b/src/api/user.js
@@ -23,3 +23,11 @@ export const mergeAccounts = async (sourceAccountIds, destinationAccountId) => {
     getAuthHeaderConfig(),
   );
 };
+
+export const assignRole = async (userId, roleId) => {
+  return axios.post(
+    API.ASSIGN_ROLE(userId),
+    { roleId: roleId },
+    getAuthHeaderConfig(),
+  )
+}

--- a/src/components/assignRolesPage/index.js
+++ b/src/components/assignRolesPage/index.js
@@ -1,0 +1,211 @@
+import React, { useState } from 'react';
+import useSWR from 'swr';
+import {
+  CircularProgress,
+  TextField,
+  Grid,
+  Typography,
+  makeStyles,
+  Button,
+  Fade,
+  // Paper,
+} from '@material-ui/core';
+import { Autocomplete } from '@material-ui/lab';
+import PersonIcon from '@material-ui/icons/Person';
+import * as strings from '../../constants/strings';
+import * as API from '../../constants/api';
+import {
+  axios,
+  formatDateToNow,
+  getAuthHeaderConfig,
+  getUserFullName,
+  getUserRole,
+} from '../../utils';
+import { Banner } from '../common';
+import { assignRole } from '../../api';
+
+const useStyles = makeStyles((theme) => ({
+  icon: {
+    color: theme.palette.text.secondary,
+    marginRight: theme.spacing(2),
+  },
+  progress: {
+    marginLeft: theme.spacing(2),
+  },
+  noSelection: {
+    padding: theme.spacing(2),
+  },
+}));
+
+const AssignRolesPage = () => {
+  const classes = useStyles();
+
+  const {
+    data: users,
+    error,
+    isValidating,
+  } = useSWR(
+    `${API.GET_USERS}/?orderCId=desc`,
+    (key) => axios.get(key, getAuthHeaderConfig()).then((res) => {
+      console.log(res);
+      return res.data
+    }),
+  );
+  const {
+    data: roles,
+  } = useSWR(
+    `${API.GET_ROLES}`,
+    (key) => axios.get(key, getAuthHeaderConfig()).then((res) => {
+      console.log(res);
+      return res.data
+    }),
+  );
+
+  const handleAddRole = async () => {
+    setAssigningRole(true);
+    setAssigningError(null);
+    setAssigningSuccess(null);
+    try {
+      await assignRole(user.id, role.id);
+      setAssigningSuccess('Role assigned to account successfully');
+    } catch (e) {
+      setAssigningError(`Error assigning role to account: ${e.message ?? e?.data?.error}`);
+    } finally {
+      setAssigningRole(false);
+    }
+  }
+
+  const [user, setUser] = useState(null);
+  const [role, setRole] = useState(null);
+  const [assigningRole, setAssigningRole] = useState(false);
+  const [assigningError, setAssigningError] = useState(null);
+  const [assigningSuccess, setAssigningSuccess] = useState(null);
+
+  return (
+    <section className="manage-client">
+      <Banner
+        header={strings.ASSIGN_ROLES_BANNER_HEADER}
+        content={strings.ASSIGN_ROLES_BANNER_CONTENT}
+      />
+      <div className="manage-client__content">
+        <div className="manage-client__steps">
+          <h3>
+            Step 1: Select the user whose role you&apos;d like to link:
+          </h3>
+          {error && (
+            <Typography color="error">
+              index.js Error occurred fetching user:{' '}
+              {error?.message ?? error?.data?.error ?? JSON.stringify(error)}
+            </Typography>
+          )}
+          {isValidating && !users && <CircularProgress />}
+          {users && (
+            <>
+              <Autocomplete
+                id="user-autocomplete-select"
+                options={users}
+                value={user}
+                openOnFocus
+                onChange={(e, user) => {
+                  setUser(user);
+                }}
+                getOptionLabel={(option) => getUserFullName(option)}
+                getOptionSelected={(option) => option.id === user.id}
+                style={{ width: 400 }}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Select user"
+                    variant="outlined"
+                  />
+                )}
+                renderOption={(option) => (
+                  <Grid container alignItems="center">
+                    <Grid item>
+                      <PersonIcon className={classes.icon} />
+                    </Grid>
+                    <Grid item xs>
+                      {getUserFullName(option)}
+                      <Typography color="textSecondary">
+                        {getUserRole(option)}
+                      </Typography>
+                      <Typography variant="body2" color="textSecondary">
+                        {formatDateToNow(option.lastLoginAt)}
+                      </Typography>
+                    </Grid>
+                  </Grid>
+                )}
+              />
+            </>
+          )}
+          <h3>Step 2: Choose role you would like to assign:</h3>
+          <Autocomplete
+              id="user-autocomplete-select"
+              options={roles}
+              value={role}
+              openOnFocus
+              onChange={(e, role) => {
+                setRole(role);
+              }}
+              getOptionLabel={(option) => option.description}
+              // getOptionSelected={(option) => option.id === user.id}
+              style={{ width: 400 }}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Select Role"
+                  variant="outlined"
+                />
+              )}
+              renderOption={(option) => (
+                <Grid container alignItems="center">
+                  <Grid item xs>
+                    <Typography>
+                      {option.description}
+                    </Typography>
+                  </Grid>
+                </Grid>
+              )}
+          />
+          {role && user && (
+            <>
+              <h3>Step 3: Confirm assigning of role</h3>
+              <Button
+                className={classes.addButton}
+                type="button"
+                onClick={handleAddRole}
+                disabled={user === null || role === null || assigningRole}
+                variant="contained"
+                color="primary"
+              >
+                Assign Role
+                {assigningRole && (
+                  <Fade
+                    in={assigningRole}
+                    style={{
+                      transitionDelay: assigningRole ? '800ms' : '0ms',
+                    }}
+                    unmountOnExit
+                  >
+                    <CircularProgress
+                      className={classes.buttonProgress}
+                      size={24}
+                    />
+                  </Fade>
+                )}
+              </Button>
+            </>
+          )}
+          {assigningError && <Typography color="error">{assigningError}</Typography>}
+          {assigningSuccess && (
+            <Typography className={classes.successMessage}>
+              {assigningSuccess}
+            </Typography>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default AssignRolesPage;

--- a/src/components/common/PermissionsField.js
+++ b/src/components/common/PermissionsField.js
@@ -11,7 +11,7 @@ import { useEditable } from '../../providers/EditableProvider';
 import MultiParagraphDisplay from './MultiParagraphDisplay';
 
 export const canUserEdit = (field, user) =>
-  permissions[user.roles[0]].includes(field);
+  permissions[user.roleId].includes(field);
 
 const PermissionsField = ({
   permission,

--- a/src/components/common/Status.js
+++ b/src/components/common/Status.js
@@ -5,9 +5,9 @@ import { PLAN_STATUS } from '../../constants/variables';
 import { NO_PLAN } from '../../constants/strings';
 import {
   isUserAgreementHolder,
-  isUserRangeOfficer,
-  isUserDecisionMaker,
-} from '../../utils';
+  isUserAgrologist,
+  isUserDecisionMaker
+} from '../../utils'
 
 const propTypes = {
   user: PropTypes.shape({}).isRequired,
@@ -85,9 +85,9 @@ const translateStatusBasedOnUser = (
       modifier += '--green';
       break;
     case PLAN_STATUS.STANDS_REVIEW:
-      if (isUserRangeOfficer(user)) {
-        statusName = 'Review Amendment';
-        modifier += '--orange';
+      if (isUserAgrologist(user)) {
+        statusName = 'Review Amendment'
+        modifier += '--orange'
       } else {
         statusName = 'Stands';
         modifier += '--green';
@@ -113,18 +113,18 @@ const translateStatusBasedOnUser = (
       break;
 
     case PLAN_STATUS.SUBMITTED_FOR_REVIEW:
-      if (isUserRangeOfficer(user)) {
-        statusName = 'Provide Feedback';
-        modifier += '--orange';
+      if (isUserAgrologist(user)) {
+        statusName = 'Provide Feedback'
+        modifier += '--orange'
       } else {
         statusName = 'Awaiting Feedback';
         modifier += '--gray';
       }
       break;
     case PLAN_STATUS.SUBMITTED_FOR_FINAL_DECISION:
-      if (isUserRangeOfficer(user)) {
-        statusName = 'Decision Required';
-        modifier += '--orange';
+      if (isUserAgrologist(user)) {
+        statusName = 'Decision Required'
+        modifier += '--orange'
       } else {
         statusName = 'Awaiting Decision';
         modifier += '--gray';
@@ -189,13 +189,13 @@ const translateStatusBasedOnUser = (
       modifier += isUserAgreementHolder(user) ? '--orange' : '--gray';
       break;
     case PLAN_STATUS.MANDATORY_AMENDMENT_STAFF:
-      statusName = 'Mandatory Amendment Created';
-      modifier += isUserRangeOfficer(user) ? '--orange' : '--gray';
-      break;
+      statusName = 'Mandatory Amendment Created'
+      modifier += isUserAgrologist(user) ? '--orange' : '--gray'
+      break
     case PLAN_STATUS.SUBMITTED_AS_MANDATORY:
-      statusName = 'Submitted as Mandatory';
-      modifier += isUserRangeOfficer(user) ? '--orange' : '--gray';
-      break;
+      statusName = 'Submitted as Mandatory'
+      modifier += isUserAgrologist(user) ? '--orange' : '--gray'
+      break
     default:
       modifier += '--not-provided';
       break;

--- a/src/components/common/Status.story.js
+++ b/src/components/common/Status.story.js
@@ -7,7 +7,7 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, select } from '@storybook/addon-knobs';
 
 const userPropOptions = {
-  'Agreement Holder': { roles: [USER_ROLE.AGREEMENT_HOLDER] },
+  'Agreement Holder': { roles: [USER_ROLE[4]] },
   'Not Agreement Holder': { roles: [] },
 };
 

--- a/src/components/mainPage/Navbar.js
+++ b/src/components/mainPage/Navbar.js
@@ -8,6 +8,7 @@ import * as Routes from '../../constants/routes';
 import { IMAGE_SRC, ELEMENT_ID } from '../../constants/variables';
 import {
   canManageClients,
+  canManageEmails,
   signOutFromSSOAndSiteMinder
 } from '../../utils'
 import { signOut } from '../../actionCreators'

--- a/src/components/mainPage/Navbar.js
+++ b/src/components/mainPage/Navbar.js
@@ -9,6 +9,7 @@ import { IMAGE_SRC, ELEMENT_ID } from '../../constants/variables';
 import {
   canManageClients,
   canManageEmails,
+  canAssignRoles,
   signOutFromSSOAndSiteMinder
 } from '../../utils'
 import { signOut } from '../../actionCreators'
@@ -17,6 +18,7 @@ import {
   MANAGE_CLIENTS,
   MERGE_ACCOUNT,
   EMAIL_TEMPLATE,
+  ASSIGN_ROLES
 } from '../../constants/strings';
 
 export class Navbar extends Component {
@@ -101,11 +103,11 @@ export class Navbar extends Component {
               )}
               {canAssignRoles(user) && (
                 <NavLink
-                to={Routes.MANAGE_CLIENT}
+                to={Routes.ASSIGN_ROLES}
                 className="navbar__link"
                 activeClassName="navbar__link--active"
               >
-                {MANAGE_CLIENTS}
+                {ASSIGN_ROLES}
                 <div className="navbar__link__underline" />
               </NavLink>
               )}

--- a/src/components/mainPage/Navbar.js
+++ b/src/components/mainPage/Navbar.js
@@ -99,6 +99,16 @@ export class Navbar extends Component {
                   <div className="navbar__link__underline" />
                 </NavLink>
               )}
+              {canAssignRoles(user) && (
+                <NavLink
+                to={Routes.MANAGE_CLIENT}
+                className="navbar__link"
+                activeClassName="navbar__link--active"
+              >
+                {MANAGE_CLIENTS}
+                <div className="navbar__link__underline" />
+              </NavLink>
+              )}
             </Fragment>
 
             <Dropdown

--- a/src/components/mainPage/Navbar.js
+++ b/src/components/mainPage/Navbar.js
@@ -7,11 +7,10 @@ import { Avatar } from '../common';
 import * as Routes from '../../constants/routes';
 import { IMAGE_SRC, ELEMENT_ID } from '../../constants/variables';
 import {
-  isUserAdmin,
-  isUserAgreementHolder,
-  signOutFromSSOAndSiteMinder,
-} from '../../utils';
-import { signOut } from '../../actionCreators';
+  canManageClients,
+  signOutFromSSOAndSiteMinder
+} from '../../utils'
+import { signOut } from '../../actionCreators'
 import {
   SELECT_RUP,
   MANAGE_CLIENTS,
@@ -69,7 +68,7 @@ export class Navbar extends Component {
                   <div className="navbar__link__underline" />
                 </NavLink>
                 */}
-              {!isUserAgreementHolder(user) && (
+              {canManageClients(user) && (
                 <>
                   <NavLink
                     to={Routes.MANAGE_CLIENT}
@@ -89,7 +88,7 @@ export class Navbar extends Component {
                   </NavLink>
                 </>
               )}
-              {isUserAdmin(user) && (
+              {canManageEmails(user) && (
                 <NavLink
                   to={Routes.EMAIL_TEMPLATE}
                   className="navbar__link"

--- a/src/components/rangeUsePlanPage/PlanForm.js
+++ b/src/components/rangeUsePlanPage/PlanForm.js
@@ -15,7 +15,7 @@ import { Attachments, AttachmentsHeader } from './attachments';
 import EditableProvider from '../../providers/EditableProvider';
 import { isUUID } from 'uuid-v4';
 import { useUser } from '../../providers/UserProvider';
-import { canUserAttachMaps, canUserAddAttachments } from '../../utils';
+import { canUserAttachMaps, canUserAddAttachments, canUserConsiderManagement, canUserAddAdditionalReqs } from '../../utils';
 
 const PlanForm = ({
   plan,
@@ -77,43 +77,47 @@ const PlanForm = ({
         name={ELEMENT_ID.ADDITIONAL_REQUIREMENTS}
         id={ELEMENT_ID.ADDITIONAL_REQUIREMENTS}
       >
-        <AdditionalRequirements
-          additionalRequirements={plan.additionalRequirements}
-        />
+        <EditableProvider editable={canUserAddAdditionalReqs(plan, user)}>
+          <AdditionalRequirements
+            additionalRequirements={plan.additionalRequirements}
+          />
+        </EditableProvider>
       </Element>
       <Element
         name={ELEMENT_ID.MANAGEMENT_CONSIDERATIONS}
         id={ELEMENT_ID.MANAGEMENT_CONSIDERATIONS}
       >
-        <ManagementConsiderations
-          planId={plan.id}
-          managementConsiderations={plan.managementConsiderations}
-        />
+        <EditableProvider editable={canUserConsiderManagement(plan, user)}>
+          <ManagementConsiderations
+            planId={plan.id}
+            managementConsiderations={plan.managementConsiderations}
+          />
+        </EditableProvider>
       </Element>
       {!isUUID(plan.id) && (
         <EditableProvider editable={canUserAddAttachments(plan, user)}>
           <Element name={ELEMENT_ID.ATTACHMENTS} id={ELEMENT_ID.ATTACHMENTS}>
             <AttachmentsHeader />
-            <Attachments
-              planId={plan.id}
-              attachments={plan.files}
-              propertyName="decisionAttachments"
-              label="Decision Material"
-            />
             <EditableProvider editable={canUserAttachMaps(plan, user)}>
+              <Attachments
+                planId={plan.id}
+                attachments={plan.files}
+                propertyName="decisionAttachments"
+                label="Decision Material"
+              />
               <Attachments
                 planId={plan.id}
                 attachments={plan.files}
                 propertyName="mapAttachments"
                 label="Map"
               />
+              <Attachments
+                planId={plan.id}
+                attachments={plan.files}
+                propertyName="otherAttachments"
+                label="Other"
+              />
             </EditableProvider>
-            <Attachments
-              planId={plan.id}
-              attachments={plan.files}
-              propertyName="otherAttachments"
-              label="Other"
-            />
           </Element>
         </EditableProvider>
       )}

--- a/src/components/rangeUsePlanPage/conditions/index.js
+++ b/src/components/rangeUsePlanPage/conditions/index.js
@@ -48,7 +48,7 @@ const Conditions = ({ plan }) => {
             fast
           />
         </div>
-        {!user.roles.includes('myra_client') && (
+        {!isUserAgreementHolder(user) && (
           <div className="rup__cell-6" style={{ marginBottom: 40 }}>
             <div className="rup__info-title" style={{ width: 500 }}>
               <div className="rup__popup-header">

--- a/src/components/rangeUsePlanPage/conditions/index.js
+++ b/src/components/rangeUsePlanPage/conditions/index.js
@@ -7,7 +7,7 @@ import PermissionsField from '../../common/PermissionsField';
 import { TextArea } from 'formik-semantic-ui';
 import { useUser } from '../../../providers/UserProvider';
 import EditableProvider from '../../../providers/EditableProvider';
-import { isStatusSubmittedForFD } from '../../../utils';
+import { isStatusSubmittedForFD, isUserAgreementHolder } from '../../../utils';
 
 const Conditions = ({ plan }) => {
   const user = useUser();

--- a/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleBox.js
+++ b/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleBox.js
@@ -49,7 +49,7 @@ const GrazingScheduleBox = ({
 
   const getScheduleError = () => {
     if (schedule.grazingScheduleEntries.length === 0) {
-      if (user.roles.includes('myra_range_officer'))
+      if (isUserAgrologist(user))
         return {
           message: 'This schedule has no associated rows.',
           type: 'warning',

--- a/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleBox.js
+++ b/src/components/rangeUsePlanPage/grazingSchedules/GrazingScheduleBox.js
@@ -18,6 +18,7 @@ import MultiParagraphDisplay from '../../common/MultiParagraphDisplay';
 import { useUser } from '../../../providers/UserProvider';
 import SortableTableHeaderCell from '../../common/SortableTableHeaderCell';
 import { resetGrazingScheduleEntryId } from '../../../utils/helper/grazingSchedule';
+import { isUserAgrologist } from '../../../utils';
 
 const GrazingScheduleBox = ({
   schedule,

--- a/src/components/rangeUsePlanPage/index.js
+++ b/src/components/rangeUsePlanPage/index.js
@@ -247,8 +247,8 @@ const Base = ({ user, history, match, location, ...props }) => {
 
               {(isUserAdmin(user) ||
                 isUserAgrologist(user) ||
-                isUserDecisionMaker(user)) ||
-                canReadAll(user) && (
+                isUserDecisionMaker(user) ||
+                canReadAll(user)) && (
                 <PageForStaff
                   references={references}
                   agreement={agreement}

--- a/src/components/rangeUsePlanPage/index.js
+++ b/src/components/rangeUsePlanPage/index.js
@@ -16,7 +16,7 @@ import {
 import {
   isUserAgreementHolder,
   isUserAdmin,
-  isUserRangeOfficer,
+  isUserAgrologist,
   getFirstFormikError,
   isUserDecisionMaker,
 } from '../../utils';
@@ -245,7 +245,7 @@ const Base = ({ user, history, match, location, ...props }) => {
               <OnSubmitValidationError callback={handleValidationError} />
 
               {(isUserAdmin(user) ||
-                isUserRangeOfficer(user) ||
+                isUserAgrologist(user) ||
                 isUserDecisionMaker(user)) && (
                 <PageForStaff
                   references={references}

--- a/src/components/rangeUsePlanPage/index.js
+++ b/src/components/rangeUsePlanPage/index.js
@@ -17,6 +17,7 @@ import {
   isUserAgreementHolder,
   isUserAdmin,
   isUserAgrologist,
+  canReadAll,
   getFirstFormikError,
   isUserDecisionMaker,
 } from '../../utils';
@@ -246,7 +247,8 @@ const Base = ({ user, history, match, location, ...props }) => {
 
               {(isUserAdmin(user) ||
                 isUserAgrologist(user) ||
-                isUserDecisionMaker(user)) && (
+                isUserDecisionMaker(user)) ||
+                canReadAll(user) && (
                 <PageForStaff
                   references={references}
                   agreement={agreement}

--- a/src/components/rangeUsePlanPage/pageForStaff/UpdateStatusDropdown.js
+++ b/src/components/rangeUsePlanPage/pageForStaff/UpdateStatusDropdown.js
@@ -257,7 +257,7 @@ class UpdateStatusDropdown extends Component {
           recommendNotReady,
           recommendForSubmission,
         ]
-      : [warningDivider, draft];
+      : [];
 
     if (isStatusStandsNotReviewed(status)) {
       return [stands, standsReview, ...overrides];

--- a/src/components/router/index.js
+++ b/src/components/router/index.js
@@ -40,6 +40,7 @@ const ManageClient = LoadableComponent(() => import('../manageClientPage'));
 const MergeAccount = LoadableComponent(() => import('../mergeAccountPage'));
 const RangeUsePlan = LoadableComponent(() => import('../rangeUsePlanPage'));
 const EmailTemplate = LoadableComponent(() => import('../emailTemplatePage'));
+const AssignRoles = LoadableComponent(() => import('../assignRolesPage'));
 const PDFView = LoadableComponent(
   () => import('../rangeUsePlanPage/pdf/PDFView'),
 );
@@ -66,6 +67,11 @@ const Router = () => {
             <ProtectedRoute
               path={Routes.EMAIL_TEMPLATE}
               component={EmailTemplate}
+              user={user}
+            />
+            <ProtectedRoute
+              path={Routes.ASSIGN_ROLES}
+              component={AssignRoles}
               user={user}
             />
             {/* Admin Routes End */}

--- a/src/components/selectRangeUsePlanPage/index.js
+++ b/src/components/selectRangeUsePlanPage/index.js
@@ -1,10 +1,10 @@
 import React, { useState } from 'react'
 import useSWR from 'swr'
 import * as API from '../../constants/api'
-import { axios, getAuthHeaderConfig, isUserAgrologist } from '../../utils'
+import { axios, getAuthHeaderConfig, isUserAgrologist, isUserReadOnly, isUserAdmin } from '../../utils'
 import Error from './Error'
 import { makeStyles } from '@material-ui/core/styles'
-import ZoneSelect from './ZoneSelect'
+import ZoneSelect, { ZoneSelectAll } from './ZoneSelect'
 import SearchBar from './SearchBar'
 import { Banner } from '../common'
 import {
@@ -58,7 +58,7 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
       onLoadingSlow: () =>
         setToastId(warningToast('Agreements are taking a while to load', -1)),
       onError: () => {
-        if (references.ZONES?.lenght > 0)
+        if (references.ZONES.length > 0)
           errorToast('Could not load agreements');
       },
       onSuccess: () => removeToast(toastId),
@@ -93,6 +93,13 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
               zones={zones}
               userZones={userZones}
               unassignedZones={unassignedZones}
+              zoneUsers={zoneUsers}
+              setSearchSelectedZones={setSearchSelectedZones}
+            />
+          )}
+          {(isUserAdmin(user) || isUserReadOnly(user)) && (
+            <ZoneSelectAll
+              zones={zones}
               zoneUsers={zoneUsers}
               setSearchSelectedZones={setSearchSelectedZones}
             />

--- a/src/components/selectRangeUsePlanPage/index.js
+++ b/src/components/selectRangeUsePlanPage/index.js
@@ -1,12 +1,12 @@
-import React, { useState } from 'react';
-import useSWR from 'swr';
-import * as API from '../../constants/api';
-import { axios, getAuthHeaderConfig, isUserRangeOfficer } from '../../utils';
-import Error from './Error';
-import { makeStyles } from '@material-ui/core/styles';
-import ZoneSelect from './ZoneSelect';
-import SearchBar from './SearchBar';
-import { Banner } from '../common';
+import React, { useState } from 'react'
+import useSWR from 'swr'
+import * as API from '../../constants/api'
+import { axios, getAuthHeaderConfig, isUserAgrologist } from '../../utils'
+import Error from './Error'
+import { makeStyles } from '@material-ui/core/styles'
+import ZoneSelect from './ZoneSelect'
+import SearchBar from './SearchBar'
+import { Banner } from '../common'
 import {
   SELECT_RUP_BANNER_HEADER,
   SELECT_RUP_BANNER_CONTENT,
@@ -88,7 +88,7 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
             placeholder={AGREEMENT_SEARCH_PLACEHOLDER}
             initialValue={term}
           />
-          {isUserRangeOfficer(user) && (
+          {isUserAgrologist(user) && (
             <ZoneSelect
               zones={zones}
               userZones={userZones}

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -75,6 +75,7 @@ export const UPDATE_AGREEMENT_ZONE = (agreementId) =>
 export const GET_REFERENCES = '/v1/reference';
 export const GET_ZONES = '/v1/zone';
 export const GET_USERS = '/v1/user';
+export const GET_ROLES = '/v1/roles';
 export const SEARCH_CLIENTS = '/v1/client/search';
 export const GET_USER_PROFILE = '/v1/user/me';
 export const UPDATE_USER_PROFILE = '/v1/user/me';
@@ -82,8 +83,9 @@ export const UPDATE_USER_PROFILE = '/v1/user/me';
 export const UPDATE_USER_ID_OF_ZONE = (zoneId) => `/v1/zone/${zoneId}/user`;
 export const CREATE_USER_CLIENT_LINK = (userId) => `/v1/user/${userId}/client`;
 export const DELETE_USER_CLIENT_LINK = (userId, clientId) =>
-  `/v1/user/${userId}/client/${clientId}`;
+`/v1/user/${userId}/client/${clientId}`;
 export const MERGE_ACCOUNTS = (userId) => `/v1/user/${userId}/merge`;
+export const ASSIGN_ROLE = (userId) => `/v1/user/${userId}/assignRole`;
 
 export const CREATE_RUP = '/v1/plan';
 export const GET_RUP = (planId) => `/v1/plan/${planId}`;

--- a/src/constants/permissions.js
+++ b/src/constants/permissions.js
@@ -18,7 +18,7 @@ import {
 } from './fields';
 
 const permissions = {
-  myra_range_officer: [
+  3: [ // Staff Agrologist
     BASIC_INFORMATION.RANGE_NAME,
     BASIC_INFORMATION.ALTERNATE_BUSINESS_NAME,
     BASIC_INFORMATION.PLAN_START_DATE,
@@ -95,7 +95,7 @@ const permissions = {
     ATTACHMENTS.ADD,
     CONDITIONS.PROPOSED_CONDITIONS,
   ],
-  myra_client: [
+  4: [ // Range Agreement Holder
     SCHEDULE.PASTURE,
     SCHEDULE.TYPE,
     SCHEDULE.ANIMALS,
@@ -115,8 +115,9 @@ const permissions = {
     MANAGEMENT_CONSIDERATIONS.DELETE,
     MANAGEMENT_CONSIDERATIONS.ADD,
   ],
-  myra_admin: [],
-  myra_decision_maker: [CONDITIONS.CONDITIONS],
+  1: [], // Admin
+  5: [], // External Auditor (read only)
+  2: [CONDITIONS.CONDITIONS], // Decision Maker
 };
 
 export default permissions;

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -12,4 +12,5 @@ export const RANGE_USE_PLAN_WITH_PARAM = '/range-use-plan/:planId';
 export const MANAGE_CLIENT = '/manage-client';
 export const MERGE_ACCOUNT = '/merge-account';
 export const EMAIL_TEMPLATE = '/email-template';
-export const ADMIN_ROUTES = [MANAGE_CLIENT, MERGE_ACCOUNT, EMAIL_TEMPLATE];
+export const ASSIGN_ROLES = '/assign-roles';
+export const ADMIN_ROUTES = [MANAGE_CLIENT, MERGE_ACCOUNT, EMAIL_TEMPLATE, ASSIGN_ROLES];

--- a/src/constants/strings.js
+++ b/src/constants/strings.js
@@ -13,6 +13,7 @@ export const SELECT_RUP = 'Select RUP';
 export const MANAGE_ZONES = 'Manage Zones';
 export const MANAGE_CLIENTS = 'Manage Clients';
 export const MERGE_ACCOUNT = 'Merge Accounts';
+export const ASSIGN_ROLES = 'Assign Roles';
 
 // Agreement Table
 export const RANGE_NUMBER = 'RAN';
@@ -274,6 +275,10 @@ export const MERGE_ACCOUNT_BANNER_CONTENT_LINE1 =
   'If an agreement holder has logged in to MyRange with multiple BCEIDS, it is advisable to merge these accounts into their most current BCEID user account.  This will make sure they see all the correct agreements on sign in, and all signatures will be marked as their own.';
 export const MERGE_ACCOUNT_BANNER_CONTENT_LINE2 =
   'Note that you can filter using the table below by hitting the 3 dots in each column, you may also select multiple FROM accounts in step 1, and one TO account in step 2.';
+export const ASSIGN_ROLES_BANNER_HEADER = 
+  'Assign Roles';
+export const ASSIGN_ROLES_BANNER_CONTENT = 
+  'Assign roles to user accounts';
 // tips
 export const CONDITIONS_TIP =
   'Review and update as needed the proposed conditions that would be imposed under FRPA 112 as part of this decision';

--- a/src/constants/variables.js
+++ b/src/constants/variables.js
@@ -129,6 +129,7 @@ export const USER_ROLE = {
   RANGE_OFFICER: 'myra_range_officer',
   AGREEMENT_HOLDER: 'myra_client',
   DECISION_MAKER: 'myra_decision_maker',
+  READ_ONLY: 'myra_read_only'
 };
 
 export const PURPOSE_OF_ACTION = {

--- a/src/constants/variables.js
+++ b/src/constants/variables.js
@@ -125,11 +125,11 @@ export const DATE_FORMAT = {
 };
 
 export const USER_ROLE = {
-  ADMINISTRATOR: 'myra_admin',
-  RANGE_OFFICER: 'myra_range_officer',
-  AGREEMENT_HOLDER: 'myra_client',
-  DECISION_MAKER: 'myra_decision_maker',
-  READ_ONLY: 'myra_read_only'
+  1: 'Admin',
+  2: 'Staff Decision Maker',
+  3: 'Staff Agrologist',
+  4: 'Range Agreement Holder',
+  5: 'External Auditor'
 };
 
 export const PURPOSE_OF_ACTION = {

--- a/src/providers/PlanProvider.js
+++ b/src/providers/PlanProvider.js
@@ -46,7 +46,8 @@ export const PlanProvider = ({ children, storePlan }) => {
 
   const fetchPlan = async (planId = currentPlanId, hard = false) => {
     setFetchingPlan(true);
-
+    
+    if (errorFetchingPlan) setErrorFetchingPlan(null);
     if (hard) {
       setCurrentPlan(null);
     }

--- a/src/utils/helper/plan.js
+++ b/src/utils/helper/plan.js
@@ -13,9 +13,9 @@ import {
   isUserAgreementHolder,
   isUserStaff,
   isUserDecisionMaker,
-  isUserRangeOfficer,
-} from './user';
-import { findConfirmationsWithUser } from './client';
+  isUserAgrologist
+} from './user'
+import { findConfirmationsWithUser } from './client'
 
 const getAmendmentTypeDescription = (amendmentTypeId, amendmentTypes) => {
   if (amendmentTypeId && amendmentTypes) {
@@ -163,10 +163,10 @@ export const isNoteRequired = (statusCode) =>
   REQUIRE_NOTES_PLAN_STATUSES.includes(statusCode);
 
 export const canUserSubmitPlan = (plan = {}, user = {}) => {
-  const { status } = plan;
-  if (!status || !status.code || !user || !user.roles) return false;
+  const { status } = plan
+  if (!status || !status.code || !user || !user.roleId) return false
 
-  if (user.roles.includes('myra_range_officer')) {
+  if (isUserAgrologist(user)) {
     return (
       doesStaffOwnPlan(plan, user) &&
       (status.code === PLAN_STATUS.STAFF_DRAFT ||
@@ -174,8 +174,8 @@ export const canUserSubmitPlan = (plan = {}, user = {}) => {
         status.code === PLAN_STATUS.SUBMITTED_AS_MANDATORY)
     );
   }
-  if (user.roles.includes('myra_client')) {
-    return canUserEditThisPlan(plan, user);
+  if (isUserAgreementHolder(user)) {
+    return canUserEditThisPlan(plan, user)
   }
 };
 
@@ -212,8 +212,8 @@ export const canUserAmendPlan = (plan = {}, user = {}) => {
 export const canUserSaveDraft = (plan = {}, user = {}) => {
   const canEdit = canUserEditThisPlan(plan, user);
 
-  if (isUserRangeOfficer(user)) {
-    return canEdit || isStatusSubmittedForFD(plan?.status);
+  if (isUserAgrologist(user)) {
+    return canEdit || isStatusSubmittedForFD(plan?.status)
   }
 
   return canEdit;
@@ -229,12 +229,12 @@ export const canUserEditThisPlan = (plan = {}, user = {}) => {
     isStatusSubmittedAsMandatory(status)
   ) {
     return (
-      user.roles.includes('myra_range_officer') && doesStaffOwnPlan(plan, user)
+      isUserAgrologist(user) && doesStaffOwnPlan(plan, user)
     );
   }
 
   if (isStatusRecommendReady(status) || isStatusRecommendNotReady(status)) {
-    return user.roles.includes('myra_decision_maker');
+    return isUserDecisionMaker(user);
   }
 
   if (
@@ -245,7 +245,7 @@ export const canUserEditThisPlan = (plan = {}, user = {}) => {
     isStatusRecommendForSubmission(status) ||
     isStatusAmendmentAH(status)
   ) {
-    return user.roles.includes('myra_client');
+    return isUserAgreementHolder(user);
   }
 
   return false;
@@ -263,8 +263,8 @@ export const canUserAttachMaps = (plan = {}, user = {}) => {
     return false;
   }
 
-  if (user.roles.includes('myra_range_officer')) {
-    return canUserEditThisPlan(plan, user);
+  if (isUserAgrologist(user)) {
+    return canUserEditThisPlan(plan, user)
   }
 };
 
@@ -280,8 +280,8 @@ export const canUserUpdateStatus = (plan = {}, user = {}) => {
       isStatusRecommendReady(status) ||
       isStatusRecommendNotReady(status) ||
       isStatusStandsReview(status)
-    );
-  } else if (isUserRangeOfficer(user)) {
+    )
+  } else if (isUserAgrologist(user)) {
     return (
       doesStaffOwnPlan(plan, user) &&
       (isStatusStaffDraft(status) ||
@@ -297,15 +297,15 @@ export const canUserUpdateStatus = (plan = {}, user = {}) => {
 export const canUserDiscardAmendment = (plan, user) => {
   if (!user || !plan) return false;
 
-  if (user.roles.includes(USER_ROLE.RANGE_OFFICER)) {
+  if (isUserAgrologist(user)) {
     return (
       doesStaffOwnPlan(plan, user) &&
       isStatusMandatoryAmendmentStaff(plan.status)
     );
   }
 
-  if (user.roles.includes(USER_ROLE.AGREEMENT_HOLDER)) {
-    return isStatusAmendmentAH(plan.status);
+  if (isUserAgreementHolder(user)) {
+    return isStatusAmendmentAH(plan.status)
   }
 
   return false;
@@ -323,8 +323,8 @@ export const canUserAmendFromLegal = (plan, user) => {
 export const canUserSubmitAsMandatory = (plan, user) => {
   if (!user || !plan) return false;
 
-  if (user.roles.includes(USER_ROLE.DECISION_MAKER)) {
-    return isStatusStandsReview(plan.status);
+  if (isUserDecisionMaker(user)) {
+    return isStatusStandsReview(plan.status)
   }
 
   return false;

--- a/src/utils/helper/plan.js
+++ b/src/utils/helper/plan.js
@@ -267,6 +267,26 @@ export const canUserAttachMaps = (plan = {}, user = {}) => {
   }
 };
 
+export const canUserAddAdditionalReqs = (plan = {}, user = {}) => {
+  if (!plan || !plan.status || !user) {
+    return false;
+  }
+
+  if (isUserAgrologist(user)) {
+    return canUserEditThisPlan(plan, user)
+  }
+};
+
+export const canUserConsiderManagement = (plan = {}, user = {}) => {
+  if (!plan || !plan.status || !user) {
+    return false;
+  }
+
+  if (isUserAgreementHolder(user)) {
+    return canUserEditThisPlan(plan, user);
+  }
+}
+
 export const canUserUpdateStatus = (plan = {}, user = {}) => {
   const { status } = plan;
   if (!status) return false;

--- a/src/utils/helper/plan.js
+++ b/src/utils/helper/plan.js
@@ -6,7 +6,6 @@ import {
   REQUIRE_NOTES_PLAN_STATUSES,
   NOT_DOWNLOADABLE_PLAN_STATUSES,
   REFERENCE_KEY,
-  USER_ROLE,
 } from '../../constants/variables';
 import { isAmendment } from './amendment';
 import {

--- a/src/utils/helper/user.js
+++ b/src/utils/helper/user.js
@@ -70,3 +70,6 @@ export const canManageClients = user =>
 
 export const canManageEmails = user =>
   user && user.permissions && user.permissions.find(p => p.id === 9);
+
+export const canReadAll = user =>
+  user && user.permissions && user.permissions.find(p => p.id === 1);

--- a/src/utils/helper/user.js
+++ b/src/utils/helper/user.js
@@ -19,6 +19,14 @@ export const getUserFullName = (user) => {
   return username;
 };
 
+export const getUserRole = (user) => {
+  const { roleId } = user || null;
+  if (roleId) {
+    return USER_ROLE[roleId];
+  }
+  return "No role in database yet";
+}
+
 export const getUserEmail = (user) => user && user.email;
 
 const getUserFamilyName = (user) =>

--- a/src/utils/helper/user.js
+++ b/src/utils/helper/user.js
@@ -71,5 +71,8 @@ export const canManageClients = user =>
 export const canManageEmails = user =>
   user && user.permissions && user.permissions.find(p => p.id === 9);
 
+export const canAssignRoles = user =>
+  user && user.permissions && user.permissions.find(p => p.id === 11);
+
 export const canReadAll = user =>
   user && user.permissions && user.permissions.find(p => p.id === 1);

--- a/src/utils/helper/user.js
+++ b/src/utils/helper/user.js
@@ -45,20 +45,28 @@ export const getUserInitial = (user) => {
 
 export const isUserActive = (user) => user && user.active;
 
-export const isUserAdmin = (user) =>
-  user && user.roles && user.roles.indexOf(USER_ROLE.ADMINISTRATOR) >= 0;
+export const isUserAdmin = user =>
+  user && user.roleId && user.roleId === 1;
 
-export const isUserRangeOfficer = (user) =>
-  user && user.roles && user.roles.indexOf(USER_ROLE.RANGE_OFFICER) >= 0;
+export const isUserReadOnly = user =>
+  user && user.roleId && user.roleId === 5;
 
-export const isUserStaff = (user) =>
-  isUserAdmin(user) || isUserRangeOfficer(user);
+export const isUserAgrologist = user =>
+  user && user.roleId && user.roleId === 3;
 
-export const isUserAgreementHolder = (user) =>
-  user && user.roles && user.roles.indexOf(USER_ROLE.AGREEMENT_HOLDER) >= 0;
+export const isUserStaff = user => isUserAdmin(user) || isUserAgrologist(user)
 
-export const isUserDecisionMaker = (user) =>
-  user && user.roles && user.roles.indexOf(USER_ROLE.DECISION_MAKER) >= 0;
+export const isUserAgreementHolder = user =>
+user && user.roleId && user.roleId === 4;
 
-export const DoesUserHaveRole = (user) =>
-  isUserAdmin(user) || isUserRangeOfficer(user) || isUserAgreementHolder(user);
+export const isUserDecisionMaker = user =>
+user && user.roleId && user.roleId === 2;
+
+export const DoesUserHaveRole = user =>
+  isUserAdmin(user) || isUserAgrologist(user) || isUserAgreementHolder(user)
+
+export const canManageClients = user =>
+  user && user.permissions && user.permissions.find(p => p.id === 8);
+
+export const canManageEmails = user =>
+  user && user.permissions && user.permissions.find(p => p.id === 9);


### PR DESCRIPTION
- Make role check consistent with new database change and setup navbar with new permissions
- Add missed files when merging
- Pair with api commit 1 to allow read only permission
- Change permission edit field to use new database role id
- WIP preparing for new assigning roles page, modules might be broken
- Add frontend for assign roles page and begin changes for how roles are read
- Clean a little bit for legacy roles stuff
- Fix plan page breaking with recent changes
- set error to null if error exists to avoid error persisting to other plans
- Remove draft option for non-admin in override options
