### PR TITLE
Persist filters and checkboxes in localstorage

### DIFF
--- a/src/components/selectRangeUsePlanPage/SortableAgreementTable.js
+++ b/src/components/selectRangeUsePlanPage/SortableAgreementTable.js
@@ -45,7 +45,7 @@ const headCells = [
     filterable: true,
   },
   {
-    id: 'plan_creator.given_name',
+    id: 'user_account.family_name',
     numeric: false,
     disablePadding: false,
     label: 'Staff Contact',

--- a/src/components/selectRangeUsePlanPage/ZoneSelect.js
+++ b/src/components/selectRangeUsePlanPage/ZoneSelect.js
@@ -359,6 +359,7 @@ export default function ZoneSelect({
     setSearchSelectedZones(selectedZones);
     if (userZones.concat(unassignedZones)?.length === selectedZones?.length) {
       setSelectAllZones(true);
+      setSaveZoneInfo(true, false, selectedZones);
     } else {
       setSelectAllZones(false);
     }

--- a/src/components/selectRangeUsePlanPage/ZoneSelect.js
+++ b/src/components/selectRangeUsePlanPage/ZoneSelect.js
@@ -283,6 +283,7 @@ export default function ZoneSelect({
   const [zoneMap, setZoneMap] = useState();
   const [selectAllZones, setSelectAllZones] = useState(true);
   const [deselectAllZones, setDeselectAllZones] = useState(false);
+  const zoneInfo = getDataFromLocalStorage("zone-info");
 
   const {
     data: users,
@@ -294,7 +295,24 @@ export default function ZoneSelect({
   );
 
   useEffect(() => {
-    if (userZones && userZones.length > 0) {
+    if (zoneInfo?.allSelected) {
+      setAllZonesSelected();
+      setSelectAllZones(true);
+      setDeselectAllZones(false);
+    } else if(zoneInfo) {
+      setSelectAllZones(false);
+    }
+    if (zoneInfo?.allDeselected) {
+      setSearchSelectedZones([]);
+      setSelectedZones([]);
+      setSelectAllZones(false);
+      setDeselectAllZones(true);
+    }
+
+    if (zoneInfo?.zones) {
+      setSelectedZones(zoneInfo.zones);
+      setSearchSelectedZones(zoneInfo.zones);
+    } else if (userZones && userZones.length > 0) {
       if (selectedZones.length === 0) {
         setAllZonesSelected();
       } else {
@@ -326,13 +344,14 @@ export default function ZoneSelect({
         {},
       );
       setZoneMap(zoneMap);
-      setAllZonesSelected();
+      if (!zoneInfo) setAllZonesSelected();
     }
   }, [zones]);
 
   const handleChange = (event) => {
     if (event.target.value !== undefined) {
       setSelectedZones(event.target.value);
+      setSaveZoneInfo(false, false, event.target.value);
     }
   };
 
@@ -375,6 +394,7 @@ export default function ZoneSelect({
               if (event.target.checked) {
                 setAllZonesSelected();
                 setDeselectAllZones(!event.target.checked);
+                setSaveZoneInfo(true, false, zones.map((zone) => zone.id));
               }
             }}
             name="selectAllZones"
@@ -393,6 +413,7 @@ export default function ZoneSelect({
                 setSearchSelectedZones([]);
                 setSelectedZones([]);
                 setSelectAllZones(!event.target.checked);
+                setSaveZoneInfo(false, true, []);
               }
             }}
             name="deselectAllZones"

--- a/src/components/selectRangeUsePlanPage/index.js
+++ b/src/components/selectRangeUsePlanPage/index.js
@@ -65,6 +65,7 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
     StringParam,
   );
   const [order = 'asc', setOrder] = useQueryParam('order', StringParam);
+  const filterInfo = getDataFromLocalStorage("filter-info");
   const [filters = { agreementCheck: 'true' }, setFilters] = useQueryParam(
     'filters',
     NewObjectParam,
@@ -77,25 +78,19 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
     // Set initial page info from localstorage
     const pageInfo = getDataFromLocalStorage("page-info");
     if (pageInfo) {
-      if (pageInfo.pageNumber) {
-        console.log("setting page to: ", pageInfo);
-        setPage(pageInfo.pageNumber);
-      }
-      if (pageInfo.pageLimit) {
-        console.log("setting page amout to: ", pageInfo.pageLimit);
-        setLimit(pageInfo.pageLimit);
-      }
+      if (pageInfo.pageNumber) setPage(pageInfo.pageNumber);
+      if (pageInfo.pageLimit) setLimit(pageInfo.pageLimit);
     }
   }, []);
-  const [planCheck = false, setPlanCheck] = useQueryParam(
+  const [planCheck = filterInfo?.planCheck || false, setPlanCheck] = useQueryParam(
     'planCheck',
     BooleanParam,
   );
-  const [agreementCheck = true, setAgreementCheck] = useQueryParam(
+  const [agreementCheck = filterInfo?.agreementCheck !== undefined ? filterInfo.agreementCheck : true, setAgreementCheck] = useQueryParam(
     'agreementCheck',
     BooleanParam,
   );
-  const [activeCheck = false, setActiveCheck] = useQueryParam(
+  const [activeCheck = filterInfo?.activeCheck || false, setActiveCheck] = useQueryParam(
     'activeCheck',
     BooleanParam,
   );
@@ -170,6 +165,15 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
     setLimit(limit);
   }
 
+  const setSaveFilterInfo = (filterCol, value) => {
+    const currFilterInfo = getDataFromLocalStorage("filter-info");
+    const filterInfo = {
+      ...currFilterInfo
+    }
+    filterInfo[filterCol] = value;
+    saveDataInLocalStorage("filter-info", filterInfo);
+  }
+
   const { agreements, totalPages, currentPage = page, totalItems } = data || {};
   const classes = useStyles();
   return (
@@ -184,7 +188,10 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
             control={
               <Checkbox
                 checked={planCheck}
-                onChange={() => setPlanCheck(!planCheck)}
+                onChange={() => {
+                  setPlanCheck(!planCheck);
+                  setSaveFilterInfo("planCheck", !planCheck);
+                }}
                 name="planCheck"
                 color="primary"
               />
@@ -195,7 +202,10 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
             control={
               <Checkbox
                 checked={agreementCheck}
-                onChange={() => setAgreementCheck(!agreementCheck)}
+                onChange={() => {
+                  setAgreementCheck(!agreementCheck);
+                  setSaveFilterInfo("agreementCheck", !agreementCheck);
+                }}
                 name="agreementCheck"
                 color="primary"
               />
@@ -206,7 +216,10 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
             control={
               <Checkbox
                 checked={activeCheck}
-                onChange={() => setActiveCheck(!activeCheck)}
+                onChange={() => {
+                  setActiveCheck(!activeCheck);
+                  setSaveFilterInfo("activeCheck", !activeCheck);
+                }}
                 name="activeCheck"
                 color="primary"
               />

--- a/src/components/selectRangeUsePlanPage/index.js
+++ b/src/components/selectRangeUsePlanPage/index.js
@@ -7,6 +7,8 @@ import {
   isUserAgrologist,
   isUserReadOnly,
   isUserAdmin,
+  getDataFromLocalStorage,
+  saveDataInLocalStorage
 } from '../../utils';
 import Error from './Error';
 import { makeStyles } from '@material-ui/core/styles';
@@ -67,9 +69,17 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
     'filters',
     NewObjectParam,
   );
+  // startup
   useEffect(() => {
     // Make sure filters don't carry over
     setFilters({ agreementCheck: 'true' });
+
+    // Set initial page info from localstorage
+    const pageInfo = getDataFromLocalStorage("page-info");
+    if (pageInfo && pageInfo.pageNumber) {
+      console.log("setting page to: ", pageInfo);
+      setPage(pageInfo.pageNumber);
+    }
   }, []);
   const [planCheck = false, setPlanCheck] = useQueryParam(
     'planCheck',
@@ -127,12 +137,22 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
       ...filters,
     };
     newFilter[filterCol] = filterVal;
-    setPage(1);
     setFilters(newFilter);
   };
 
-  const setPage = (page) =>
+  const setPage = (page) => {
     history.replace(`/home/${page}/${history.location.search}`);
+  }
+
+  const setPageAndSave = (page) => {
+    history.replace(`/home/${page}/${history.location.search}`);
+    const currPageInfo = getDataFromLocalStorage("page-info");
+    const pageInfo = {
+      ...currPageInfo,
+      pageNumber: page
+    }
+    saveDataInLocalStorage("page-info", pageInfo);
+  }
 
   const { agreements, totalPages, currentPage = page, totalItems } = data || {};
   const classes = useStyles();
@@ -206,7 +226,7 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
             totalPages={totalPages}
             totalAgreements={totalItems}
             perPage={limit}
-            onPageChange={(page) => setPage(page + 1)}
+            onPageChange={(page) => setPageAndSave(page + 1)}
             onLimitChange={setLimit}
             loading={isValidating}
             onOrderChange={(orderBy, order) => {
@@ -215,12 +235,14 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
             }}
             onFilterChange={(filterCol, filterVal) => {
               addToFilters(filterCol, filterVal);
+              setPage(1);
             }}
             orderBy={orderBy}
             order={order}
             filters={filters}
             onStatusCodeChange={(filterCol, filterVal) => {
               addToFilters(filterCol, filterVal);
+              setPage(1);
             }}
           />
         </>

--- a/src/components/selectRangeUsePlanPage/index.js
+++ b/src/components/selectRangeUsePlanPage/index.js
@@ -76,9 +76,15 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
 
     // Set initial page info from localstorage
     const pageInfo = getDataFromLocalStorage("page-info");
-    if (pageInfo && pageInfo.pageNumber) {
-      console.log("setting page to: ", pageInfo);
-      setPage(pageInfo.pageNumber);
+    if (pageInfo) {
+      if (pageInfo.pageNumber) {
+        console.log("setting page to: ", pageInfo);
+        setPage(pageInfo.pageNumber);
+      }
+      if (pageInfo.pageLimit) {
+        console.log("setting page amout to: ", pageInfo.pageLimit);
+        setLimit(pageInfo.pageLimit);
+      }
     }
   }, []);
   const [planCheck = false, setPlanCheck] = useQueryParam(
@@ -154,6 +160,16 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
     saveDataInLocalStorage("page-info", pageInfo);
   }
 
+  const setPageLimitAndSave = (limit) => {
+    const currPageInfo = getDataFromLocalStorage("page-info");
+    const pageInfo = {
+      ...currPageInfo,
+      pageLimit: limit
+    }
+    saveDataInLocalStorage("page-info", pageInfo);
+    setLimit(limit);
+  }
+
   const { agreements, totalPages, currentPage = page, totalItems } = data || {};
   const classes = useStyles();
   return (
@@ -227,7 +243,7 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
             totalAgreements={totalItems}
             perPage={limit}
             onPageChange={(page) => setPageAndSave(page + 1)}
-            onLimitChange={setLimit}
+            onLimitChange={setPageLimitAndSave}
             loading={isValidating}
             onOrderChange={(orderBy, order) => {
               setOrder(order);

--- a/src/components/selectRangeUsePlanPage/index.js
+++ b/src/components/selectRangeUsePlanPage/index.js
@@ -171,6 +171,8 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
   }
 
   const setSaveFilterInfo = (filterCol, value) => {
+    if (!filtersInitialized) return; // Avoid empty update
+
     const currFilterInfo = getDataFromLocalStorage("filter-info");
     const filterInfo = {
       ...currFilterInfo
@@ -277,6 +279,7 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
             filters={filters}
             onStatusCodeChange={(filterCol, filterVal) => {
               addToFilters(filterCol, filterVal);
+              setSaveFilterInfo(filterCol, filterVal);
               setPage(1);
             }}
           />

--- a/src/components/selectRangeUsePlanPage/index.js
+++ b/src/components/selectRangeUsePlanPage/index.js
@@ -70,17 +70,21 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
     'filters',
     NewObjectParam,
   );
+  const [filtersInitialized, setFiltersInitialized] = useState(false);
   // startup
   useEffect(() => {
-    // Make sure filters don't carry over
-    setFilters({ agreementCheck: 'true' });
-
     // Set initial page info from localstorage
     const pageInfo = getDataFromLocalStorage("page-info");
     if (pageInfo) {
       if (pageInfo.pageNumber) setPage(pageInfo.pageNumber);
       if (pageInfo.pageLimit) setLimit(pageInfo.pageLimit);
     }
+    // Initialize filters
+    setFilters({ 
+      ...filterInfo,
+      agreementCheck: 'true',
+    });
+    setFiltersInitialized(true);  // Workaround flag for checkbox racing the filter initialization
   }, []);
   const [planCheck = filterInfo?.planCheck || false, setPlanCheck] = useQueryParam(
     'planCheck',
@@ -95,14 +99,15 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
     BooleanParam,
   );
   useEffect(() => {
-    addToFilters('planCheck', planCheck);
+    if (filtersInitialized) addToFilters('planCheck', planCheck);
   }, [planCheck]);
   useEffect(() => {
-    addToFilters('agreementCheck', agreementCheck);
+    if (filtersInitialized) addToFilters('agreementCheck', agreementCheck);
   }, [agreementCheck]);
   useEffect(() => {
-    addToFilters('activeCheck', activeCheck);
+    if (filtersInitialized) addToFilters('activeCheck', activeCheck);
   }, [activeCheck]);
+
   const { warningToast, removeToast, errorToast } = useToast();
 
   const references = useReferences();
@@ -264,6 +269,7 @@ const SelectRangeUsePlanPage = ({ match, history }) => {
             }}
             onFilterChange={(filterCol, filterVal) => {
               addToFilters(filterCol, filterVal);
+              setSaveFilterInfo(filterCol, filterVal);
               setPage(1);
             }}
             orderBy={orderBy}


### PR DESCRIPTION
- Edit which name column to sort by
- Save page number in localstorage and load it on startup
- Save page limit in localstorage aside the number
- Persist filter checkboxes on multiple page change
- Persist filters in localstorage
- Persist checkbox with extra initialize flag
- Persist zones for admin
- Persist zones for agrologist
- Store zones on handle close
